### PR TITLE
fix(security): sanitize shell execution (#4)

### DIFF
--- a/src/launcher.test.ts
+++ b/src/launcher.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // Mock child_process before importing launcher
 const mockExecSync = vi.fn();
+const mockExecFileSync = vi.fn();
 vi.mock("node:child_process", () => ({
   execSync: (...args: unknown[]) => mockExecSync(...args),
+  execFileSync: (...args: unknown[]) => mockExecFileSync(...args),
 }));
 
 // Mock config
@@ -224,8 +226,9 @@ describe("command dependency checks", () => {
     expect(mockQuestion.mock.calls[0]![0]).toContain(
       "npm install -g @anthropic-ai/claude-code",
     );
-    expect(mockExecSync).toHaveBeenCalledWith(
-      "npm install -g @anthropic-ai/claude-code",
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "npm",
+      ["install", "-g", "@anthropic-ai/claude-code"],
       { stdio: "inherit" },
     );
   });
@@ -337,9 +340,10 @@ describe("ensureCommand error paths", () => {
       if (cmd === "command -v claude") throw new Error("not found");
       if (typeof cmd === "string" && cmd.startsWith("command -v "))
         return Buffer.from("/usr/bin/stub");
-      if (typeof cmd === "string" && cmd.includes("npm install -g"))
-        throw new Error("install failed");
       return "";
+    });
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error("install failed");
     });
     vi.mocked(getConfig).mockReturnValue(undefined);
 
@@ -366,10 +370,9 @@ describe("ensureCommand error paths", () => {
       if (cmd === "command -v claude") throw new Error("not found");
       if (typeof cmd === "string" && cmd.startsWith("command -v "))
         return Buffer.from("/usr/bin/stub");
-      if (typeof cmd === "string" && cmd.includes("npm install -g"))
-        return Buffer.from("");
       return "";
     });
+    mockExecFileSync.mockReturnValue(Buffer.from(""));
     vi.mocked(getConfig).mockReturnValue(undefined);
 
     mockQuestion.mockImplementation((_q: string, cb: (a: string) => void) => {
@@ -414,8 +417,63 @@ describe("lazygit install handler", () => {
 
     expect(mockQuestion).toHaveBeenCalledTimes(1);
     expect(mockQuestion.mock.calls[0]![0]).toContain("brew install lazygit");
-    expect(mockExecSync).toHaveBeenCalledWith("brew install lazygit", {
-      stdio: "inherit",
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "brew",
+      ["install", "lazygit"],
+      { stdio: "inherit" },
+    );
+  });
+});
+
+describe("command name validation", () => {
+  it("rejects command names with shell injection characters", async () => {
+    vi.mocked(getConfig).mockImplementation((key: string) => {
+      if (key === "editor") return "foo; rm -rf /";
+      return undefined;
+    });
+
+    const mockExit = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(launch("/tmp/workspace")).rejects.toThrow("process.exit");
+    expect(mockExit).toHaveBeenCalledWith(1);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Invalid command name"),
+    );
+    mockExit.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it("rejects command names with backticks", async () => {
+    vi.mocked(getConfig).mockImplementation((key: string) => {
+      if (key === "editor") return "`evil`";
+      return undefined;
+    });
+
+    const mockExit = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(launch("/tmp/workspace")).rejects.toThrow("process.exit");
+    expect(mockExit).toHaveBeenCalledWith(1);
+    mockExit.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it("accepts valid command names with dots and hyphens", async () => {
+    vi.mocked(getConfig).mockImplementation((key: string) => {
+      if (key === "editor") return "my-editor.v2";
+      if (key === "sidebar") return "htop";
+      return undefined;
+    });
+
+    await launch("/tmp/workspace");
+
+    expect(mockExecSync).toHaveBeenCalledWith("command -v my-editor.v2", {
+      stdio: "ignore",
     });
   });
 });

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -1,11 +1,13 @@
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { createInterface } from "node:readline";
-import { execSync } from "node:child_process";
+import { execSync, execFileSync } from "node:child_process";
 import { planLayout, isPresetName, getPreset } from "./layout.js";
 import type { LayoutOptions } from "./layout.js";
 import { getConfig, readKVFile } from "./config.js";
 import { generateAppleScript } from "./script.js";
+
+const SAFE_COMMAND_RE = /^[a-zA-Z0-9_][a-zA-Z0-9_.+-]*$/;
 
 export interface CLIOverrides {
   layout?: string;
@@ -30,6 +32,10 @@ function executeScript(script: string): void {
 }
 
 function isCommandInstalled(cmd: string): boolean {
+  if (!SAFE_COMMAND_RE.test(cmd)) {
+    console.error(`Invalid command name: "${cmd}". Command names may only contain letters, digits, hyphens, dots, underscores, and plus signs.`);
+    process.exit(1);
+  }
   try {
     execSync(`command -v ${cmd}`, { stdio: "ignore" });
     return true;
@@ -48,12 +54,12 @@ function prompt(question: string): Promise<string> {
   });
 }
 
-const KNOWN_INSTALL_COMMANDS: Record<string, () => string | null> = {
-  claude: () => "npm install -g @anthropic-ai/claude-code",
+const KNOWN_INSTALL_COMMANDS: Record<string, () => [string, string[]] | null> = {
+  claude: () => ["npm", ["install", "-g", "@anthropic-ai/claude-code"]],
   lazygit: () => {
     try {
       execSync("command -v brew", { stdio: "ignore" });
-      return "brew install lazygit";
+      return ["brew", ["install", "lazygit"]];
     } catch {
       return null;
     }
@@ -76,17 +82,20 @@ async function ensureCommand(cmd: string): Promise<void> {
     process.exit(1);
   }
 
+  const [installBin, installArgs] = installCmd;
+  const installDisplay = [installBin, ...installArgs].join(" ");
+
   console.log(`\`${cmd}\` is required but not installed on this machine.`);
-  const answer = await prompt(`Install it now with \`${installCmd}\`? [Y/n] `);
+  const answer = await prompt(`Install it now with \`${installDisplay}\`? [Y/n] `);
 
   if (answer && answer !== "y" && answer !== "yes") {
     console.log(`\`${cmd}\` is required for this workspace layout. Exiting.`);
     process.exit(1);
   }
 
-  console.log(`Running: ${installCmd}`);
+  console.log(`Running: ${installDisplay}`);
   try {
-    execSync(installCmd, { stdio: "inherit" });
+    execFileSync(installBin, installArgs, { stdio: "inherit" });
   } catch {
     console.error(
       `Failed to install \`${cmd}\`. Please install it manually and try again.`,

--- a/src/script.test.ts
+++ b/src/script.test.ts
@@ -138,4 +138,12 @@ describe("generateAppleScript", () => {
     expect(script).toContain('vim \\"test\\"');
     expect(script).toContain("path\\\\to\\\\bin");
   });
+
+  it("escapes newlines and carriage returns in commands", () => {
+    const plan = planLayout({ editor: "vim", sidebarCommand: "cmd\ninjection\rtest" });
+    const script = generateAppleScript(plan, "/tmp");
+
+    expect(script).toContain("cmd\\ninjection\\rtest");
+    expect(script).not.toContain("\n" + "injection");
+  });
 });

--- a/src/script.ts
+++ b/src/script.ts
@@ -1,7 +1,11 @@
 import type { LayoutPlan } from "./layout.js";
 
 function escapeAppleScript(s: string): string {
-  return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return s
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r");
 }
 
 export function generateAppleScript(plan: LayoutPlan, targetDir: string): string {


### PR DESCRIPTION
## Summary
- Validate command names against safe pattern before shell interpolation (fixes command injection)
- Use `execFileSync` for install commands instead of `execSync` with strings
- Escape newlines/carriage returns in AppleScript strings

Closes #4

## Test plan
- [x] New tests for command name validation (injection payloads rejected)
- [x] New test for AppleScript newline escaping
- [x] Updated install command tests for execFileSync
- [x] All 80 tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)