### PR TITLE
fix(ux): change cli preset to plain shell (#5)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ Layout presets:
   minimal       1 editor pane, no server
   full          3 editor panes + server (default)
   pair          2 editor panes + server
-  cli           1 editor pane + server (npm login)
+  cli           1 editor pane + server
   mtop          editor + mtop + server + lazygit sidebar
 
 Per-project config:

--- a/src/layout.test.ts
+++ b/src/layout.test.ts
@@ -127,12 +127,12 @@ describe("layout presets", () => {
     expect(plan.hasServer).toBe(true);
   });
 
-  it("cli preset: 1 editor pane, server runs npm login", () => {
+  it("cli preset: 1 editor pane, server as plain shell", () => {
     const plan = planLayout(getPreset("cli"));
     expect(plan.leftColumnCount).toBe(1);
     expect(plan.rightColumnEditorCount).toBe(0);
     expect(plan.hasServer).toBe(true);
-    expect(plan.serverCommand).toBe("npm login");
+    expect(plan.serverCommand).toBeNull();
   });
 
   it("mtop preset: 2 editor panes with mtop as secondary editor, server enabled", () => {

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -44,7 +44,7 @@ const PRESETS: Record<PresetName, Partial<LayoutOptions>> = {
   minimal: { editorPanes: 1, server: "false" },
   full: { editorPanes: 3, server: "true" },
   pair: { editorPanes: 2, server: "true" },
-  cli: { editorPanes: 1, server: "npm login" },
+  cli: { editorPanes: 1, server: "true" },
   mtop: { editorPanes: 2, server: "true", secondaryEditor: "mtop" },
 };
 


### PR DESCRIPTION
## Summary
- Change `cli` preset server from `npm login` to `true` (plain shell)
- Update help text to remove confusing `(npm login)` description

Closes #5

## Test plan
- [x] Updated preset test expectations
- [x] All 76 tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)