### PR TITLE
test: add CLI integration tests (#6)

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,17 +1,20 @@
-import { spawnSync } from "node:child_process";
+import { spawnSync, execSync } from "node:child_process";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, it, expect, beforeAll } from "vitest";
-import { execSync } from "node:child_process";
+
+const PROJECT_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
 function run(...args: string[]) {
   return spawnSync("node", ["dist/index.js", ...args], {
     encoding: "utf-8",
-    cwd: "/tmp/summon-wt-6",
+    cwd: PROJECT_ROOT,
     env: { ...process.env, HOME: process.env.HOME },
   });
 }
 
 beforeAll(() => {
-  execSync("pnpm build", { cwd: "/tmp/summon-wt-6", stdio: "ignore" });
+  execSync("pnpm build", { cwd: PROJECT_ROOT, stdio: "ignore" });
 });
 
 describe("CLI integration", () => {


### PR DESCRIPTION
## Summary
- Add 10 integration tests for CLI entry point (`index.test.ts`)
- Tests cover: --help, --version, invalid flags, subcommand arg validation, error messages

Closes #6

## Test plan
- [x] 86 tests pass (76 existing + 10 new)
- [x] Tests spawn built CLI as child process

🤖 Generated with [Claude Code](https://claude.com/claude-code)