### PR TITLE
refactor: remove dead exports, add coverage thresholds (#7)

### DIFF
--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -102,7 +102,7 @@ async function ensureCommand(cmd: string): Promise<void> {
   console.log(`\`${cmd}\` installed successfully!\n`);
 }
 
-export interface ResolvedConfig {
+interface ResolvedConfig {
   opts: Partial<LayoutOptions>;
 }
 

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -38,7 +38,7 @@ function parseServer(value: string): { hasServer: boolean; serverCommand: string
   return { hasServer: true, serverCommand: value };
 }
 
-export type PresetName = "minimal" | "full" | "pair" | "cli" | "mtop";
+type PresetName = "minimal" | "full" | "pair" | "cli" | "mtop";
 
 const PRESETS: Record<PresetName, Partial<LayoutOptions>> = {
   minimal: { editorPanes: 1, server: "false" },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,12 @@ export default defineConfig({
       provider: "v8",
       include: ["src/**/*.ts"],
       exclude: ["src/**/*.test.ts"],
+      thresholds: {
+        statements: 60,
+        branches: 55,
+        functions: 85,
+        lines: 60,
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary
- Remove unused `export` from `PresetName` type and `ResolvedConfig` interface
- Add coverage thresholds to vitest config (60% statements/lines, 55% branches, 85% functions)

Closes #7

## Test plan
- [x] All 76 tests pass
- [x] Typecheck confirms no external consumers of removed exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)