### PR TITLE
refactor: extract parseIntOption and hoist regex (#9)

### DIFF
--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -102,6 +102,24 @@ async function ensureCommand(cmd: string): Promise<void> {
   console.log(`\`${cmd}\` installed successfully!\n`);
 }
 
+function parseIntOption(
+  raw: string | undefined,
+  name: string,
+  min: number,
+  max: number,
+  defaultVal?: number,
+): number | undefined {
+  if (raw === undefined) return defaultVal;
+  const parsed = parseInt(raw, 10);
+  if (Number.isNaN(parsed) || parsed < min || parsed > max) {
+    const range = max === Infinity ? `a positive integer` : `${min}-${max}`;
+    const def = defaultVal ?? (name === "panes" ? 3 : 75);
+    console.warn(`Invalid ${name} value: "${raw}". Must be ${range}. Using default (${def}).`);
+    return def;
+  }
+  return parsed;
+}
+
 export interface ResolvedConfig {
   opts: Partial<LayoutOptions>;
 }
@@ -135,28 +153,8 @@ export function resolveConfig(targetDir: string, cliOverrides: CLIOverrides): Re
   const result: Partial<LayoutOptions> = { ...base };
   if (editor !== undefined) result.editor = editor;
   if (sidebar !== undefined) result.sidebarCommand = sidebar;
-  if (panes !== undefined) {
-    const parsed = parseInt(panes, 10);
-    if (Number.isNaN(parsed) || parsed < 1) {
-      console.warn(
-        `Invalid panes value: "${panes}". Must be a positive integer. Using default (3).`,
-      );
-      result.editorPanes = 3;
-    } else {
-      result.editorPanes = parsed;
-    }
-  }
-  if (editorSize !== undefined) {
-    const parsed = parseInt(editorSize, 10);
-    if (Number.isNaN(parsed) || parsed < 1 || parsed > 99) {
-      console.warn(
-        `Invalid editor-size value: "${editorSize}". Must be 1-99. Using default (75).`,
-      );
-      result.editorSize = 75;
-    } else {
-      result.editorSize = parsed;
-    }
-  }
+  result.editorPanes = parseIntOption(panes, "panes", 1, Infinity, result.editorPanes);
+  result.editorSize = parseIntOption(editorSize, "editor-size", 1, 99, result.editorSize);
   if (server !== undefined) result.server = server;
 
   return { opts: result };

--- a/src/script.ts
+++ b/src/script.ts
@@ -1,7 +1,10 @@
 import type { LayoutPlan } from "./layout.js";
 
+const RE_BACKSLASH = /\\/g;
+const RE_QUOTE = /"/g;
+
 function escapeAppleScript(s: string): string {
-  return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return s.replace(RE_BACKSLASH, "\\\\").replace(RE_QUOTE, '\\"');
 }
 
 export function generateAppleScript(plan: LayoutPlan, targetDir: string): string {


### PR DESCRIPTION
## Summary
- Extract `parseIntOption()` helper to deduplicate panes/editor-size validation
- Hoist regex literals in `escapeAppleScript` to module-level constants

Closes #9

## Test plan
- [x] All 76 existing tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)