### PR TITLE
feat: add --dry-run flag (#10)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ Options:
   --editor-size <n>           Override editor width %
   --sidebar <cmd>             Override sidebar command
   --server <value>            Server pane: true, false, or a command
+  -n, --dry-run               Print generated AppleScript without executing
 
 Config keys:
   editor        Command for coding panes (default: claude)
@@ -81,6 +82,7 @@ const parseOpts = {
     "editor-size": { type: "string" },
     sidebar: { type: "string" },
     server: { type: "string" },
+    "dry-run": { type: "boolean", short: "n" },
   },
 } as const;
 
@@ -214,6 +216,7 @@ switch (subcommand) {
     if (values["editor-size"]) overrides["editor-size"] = values["editor-size"];
     if (values.sidebar) overrides.sidebar = values.sidebar;
     if (values.server) overrides.server = values.server;
+    if (values["dry-run"]) overrides.dryRun = true;
 
     await launch(targetDir, overrides);
   }

--- a/src/launcher.test.ts
+++ b/src/launcher.test.ts
@@ -98,6 +98,21 @@ describe("script execution", () => {
     );
   });
 
+  it("prints script to stdout in dry-run mode without executing", async () => {
+    vi.mocked(getConfig).mockReturnValue(undefined);
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await launch("/tmp/workspace", { dryRun: true });
+
+    expect(logSpy).toHaveBeenCalledWith('tell application "Ghostty"\nend tell');
+    // osascript should NOT have been called
+    expect(mockExecSync).not.toHaveBeenCalledWith(
+      "osascript",
+      expect.anything(),
+    );
+    logSpy.mockRestore();
+  });
+
   it("passes correct plan and directory to generateAppleScript", async () => {
     vi.mocked(getConfig).mockReturnValue(undefined);
 

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -16,6 +16,7 @@ export interface CLIOverrides {
   "editor-size"?: string;
   sidebar?: string;
   server?: string;
+  dryRun?: boolean;
 }
 
 function ensureGhostty(): void {
@@ -194,5 +195,11 @@ export async function launch(targetDir: string, cliOverrides?: CLIOverrides): Pr
   }
 
   const script = generateAppleScript(plan, targetDir);
+
+  if (cliOverrides?.dryRun) {
+    console.log(script);
+    return;
+  }
+
   executeScript(script);
 }


### PR DESCRIPTION
## Summary
- Add `--dry-run` / `-n` flag to print generated AppleScript without executing
- Useful for debugging layouts and building trust before execution

Closes #10

## Test plan
- [x] New test verifies dry-run prints script and skips osascript
- [x] All 77 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)