### PR TITLE
fix(ux): exit code 1 on bare invocation (#11)

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -32,10 +32,10 @@ describe("CLI integration", () => {
     expect(result.stdout.trim()).toMatch(/^\d+\.\d+\.\d+$/);
   });
 
-  it("shows help and exits 0 with no arguments", () => {
+  it("shows help and exits 1 with no arguments", () => {
     const result = run();
-    expect(result.status).toBe(0);
-    expect(result.stdout).toContain("Usage:");
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Usage:");
   });
 
   it("errors on invalid flag and exits 1", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,8 +112,8 @@ if (values.help) {
 const [subcommand, ...args] = positionals;
 
 if (!subcommand) {
-  showHelp();
-  process.exit(0);
+  console.error(HELP);
+  process.exit(1);
 }
 
 switch (subcommand) {


### PR DESCRIPTION
## Summary
- Bare `summon` (no args) now exits 1 and outputs help to stderr
- `--help` flag still exits 0 with stdout output (unchanged)

Closes #11

## Test plan
- [x] All 76 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)