### PR TITLE
fix(script): work around Ghostty `make new window` AppleScript bug

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -601,7 +601,7 @@ describe("CLI integration", () => {
     it("--new-window flag accepted in dry-run", () => {
       const result = run(".", "--new-window", "--dry-run");
       expect(result.status).toBe(0);
-      expect(result.stdout).toContain("make new window");
+      expect(result.stdout).toContain('keystroke "n" using command down');
     });
 
     it("--fullscreen flag accepted in dry-run", () => {

--- a/src/script.test.ts
+++ b/src/script.test.ts
@@ -592,15 +592,11 @@ describe("generateAppleScript", () => {
       expect(exportIdx).toBeLessThan(cdIdx);
     });
 
-    it("root pane does NOT receive export when using new-window (inherits from cfg)", () => {
+    it("root pane receives export even in new-window mode (Cmd+N doesn't apply cfg)", () => {
       const plan = planLayout({ newWindow: true });
       const script = generateAppleScript(plan, "/tmp/proj", "/bin/zsh", configPath);
-      // env vars are on surface config, root pane created with cfg
-      const lines = script.split("\n");
-      const inputTextExports = lines.filter(
-        (l) => l.includes("input text") && l.includes("export STARSHIP_CONFIG"),
-      );
-      expect(inputTextExports.length).toBe(0);
+      const exportIdx = script.indexOf("export STARSHIP_CONFIG=");
+      expect(exportIdx).toBeGreaterThan(-1);
     });
 
     it("config-launched panes do NOT embed export in -lc argument (env on surface config)", () => {
@@ -679,19 +675,21 @@ describe("generateAppleScript", () => {
 
   describe("window management flags", () => {
     describe("new-window flag", () => {
-      it("generates 'make new window' when newWindow=true", () => {
+      it("uses System Events Cmd+N when newWindow=true", () => {
         const plan = planLayout({ newWindow: true });
         const script = generateAppleScript(plan, "/tmp/test");
-        expect(script).toContain("make new window with configuration cfg");
-        expect(script).not.toContain("set win to front window");
-        expect(script).toContain("delay 0.3");
+        expect(script).toContain('tell application "System Events"');
+        expect(script).toContain('keystroke "n" using command down');
+        expect(script).toContain("delay 0.5");
+        expect(script).toContain("set win to front window");
+        expect(script).not.toContain("make new window");
       });
 
-      it("uses front window when newWindow=false (default)", () => {
+      it("uses front window without new window when newWindow=false (default)", () => {
         const plan = planLayout();
         const script = generateAppleScript(plan, "/tmp/test");
         expect(script).toContain("set win to front window");
-        expect(script).not.toContain("make new window");
+        expect(script).not.toContain('keystroke "n" using command down');
       });
     });
 
@@ -787,11 +785,11 @@ describe("generateAppleScript", () => {
       expect(script).not.toContain('export FOO=bar; rm -rf /');
     });
 
-    it("skips root pane exports in new-window mode", () => {
+    it("exports env vars to root pane in new-window mode (Cmd+N doesn't apply cfg)", () => {
       const plan = planLayout({ newWindow: true });
       const script = generateAppleScript(plan, "/tmp", "/bin/bash", null,
         { NODE_ENV: "development" });
-      expect(script).not.toContain("export NODE_ENV=");
+      expect(script).toContain("export NODE_ENV=");
     });
 
     it("no env var setup when none configured", () => {

--- a/src/script.ts
+++ b/src/script.ts
@@ -72,12 +72,17 @@ export function generateAppleScript(plan: LayoutPlan, targetDir: string, loginSh
   blank();
 
   // Get or create window for workspace
+  // Note: Ghostty's `make new window` returns an unusable tab-group reference
+  // (AppleScript error -2710), so we use Cmd+N via System Events as a workaround.
   if (plan.newWindow) {
-    add(1, "set win to make new window with configuration cfg");
-    add(1, "delay 0.3");
-  } else {
-    add(1, "set win to front window");
+    add(1, 'tell application "System Events"');
+    add(2, 'tell process "Ghostty"');
+    add(3, 'keystroke "n" using command down');
+    add(2, "end tell");
+    add(1, "end tell");
+    add(1, "delay 0.5");
   }
+  add(1, "set win to front window");
   add(1, "set paneRoot to terminal 1 of selected tab of win");
   blank();
 
@@ -192,11 +197,10 @@ export function generateAppleScript(plan: LayoutPlan, targetDir: string, loginSh
 
   blank();
 
-  // Root pane env var exports: only needed when NOT using new-window mode
-  // (root pane from front window was not created with cfg, so it doesn't inherit env vars)
-  // In new-window mode, root pane was created with cfg and inherits env vars automatically.
-  // Split panes always inherit env vars from cfg — no input text needed for them.
-  if (allEnvVars.length > 0 && !plan.newWindow) {
+  // Root pane env var exports: the root pane is never created with cfg
+  // (it's either the existing front window terminal, or a new window via Cmd+N),
+  // so it needs explicit exports. Split panes inherit env vars from cfg automatically.
+  if (allEnvVars.length > 0) {
     for (const envVar of allEnvVars) {
       const eqIdx = envVar.indexOf("=");
       const key = envVar.slice(0, eqIdx);


### PR DESCRIPTION
## Summary

- **`make new window`** (with or without configuration) returns a tab-group reference that causes AppleScript error -2710, making `--new-window` completely broken
- Replaced with `Cmd+N` via System Events, which creates the window correctly and allows `front window` to resolve to a usable reference
- Removed the `!plan.newWindow` guard on root pane env var exports — root pane is never created with surface configuration in either code path, so it always needs explicit `export` commands

## Root cause

Ghostty bug: `make new window` registers the window with a `tab-group-*` ID in the AppleScript object model, which cannot be dereferenced by subsequent commands. Filed as ghostty-org/ghostty#11500 (auto-closed — requires vouched contributor status).

## Test plan

- [x] Minimal AppleScript repro confirms `make new window` fails and `Cmd+N` works
- [x] `summon . --new-window` opens a new window and creates all panes correctly
- [x] `summon . --new-window --env MY_VAR=test` propagates env vars to all panes
- [x] `summon . --dry-run` (without `--new-window`) unchanged — no System Events block
- [x] 523 tests pass, typecheck and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)