### PR TITLE
fix(ci): add --access public to npm publish for provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,4 +24,4 @@ jobs:
       - run: pnpm lint
       - run: pnpm test
       - run: pnpm build
-      - run: npm publish --provenance
+      - run: npm publish --provenance --access public


### PR DESCRIPTION
Fixes the 404 error on trusted publishing. The first provenance publish needs --access public.