### PR TITLE
fix(ci): remove registry-url for npm trusted publishing OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,6 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
-          registry-url: https://registry.npmjs.org
       - run: pnpm install --frozen-lockfile
       - run: pnpm typecheck
       - run: pnpm lint


### PR DESCRIPTION
Fixes npm 404 on publish — setup-node's registry-url creates an .npmrc that overrides OIDC auth.