### PR TITLE
fix(ci): npm publish with token + registry-url

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
+          registry-url: https://registry.npmjs.org
       - run: pnpm install --frozen-lockfile
       - run: pnpm typecheck
       - run: pnpm lint


### PR DESCRIPTION
Restores registry-url and NODE_AUTH_TOKEN for reliable npm publishing.