### PR TITLE
security(audit-p1): remediate all 5 findings from 2026-04-19 deep audit

### DIFF
--- a/src/commands/layout-support.test.ts
+++ b/src/commands/layout-support.test.ts
@@ -129,6 +129,14 @@ describe("validateLayoutOrExit", () => {
     expect(errorSpy).toHaveBeenCalledWith("Valid presets: minimal, pair");
     expect(errorSpy).toHaveBeenCalledWith("Custom layouts: team-layout");
   });
+
+  it("exits via exitWithUsageHint on path-traversal input, does not throw", () => {
+    mockIsCustomLayout.mockImplementationOnce(() => {
+      throw new Error('Invalid layout path: "../../../etc/passwd"');
+    });
+    expect(() => validateLayoutOrExit("../../../etc/passwd", "--layout")).toThrow("usage:");
+    expect(mockExitWithUsageHint).toHaveBeenCalledWith("Error: --layout is not a valid layout name.");
+  });
 });
 
 describe("layoutNotFoundOrExit", () => {

--- a/src/commands/layout-support.ts
+++ b/src/commands/layout-support.ts
@@ -58,7 +58,14 @@ export function validateLayoutNameOrExit(name: string): void {
 }
 
 export function validateLayoutOrExit(value: string, label: string): void {
-  if (!isPresetName(value) && !isCustomLayout(value)) {
+  let customMatch: boolean;
+  try {
+    customMatch = isCustomLayout(value);
+  } catch {
+    exitWithUsageHint(`Error: ${label} is not a valid layout name.`);
+    return;
+  }
+  if (!isPresetName(value) && !customMatch) {
     console.error(`Error: ${label} must be a valid preset or custom layout name, got "${value}".`);
     console.error(`Valid presets: ${getPresetNames().join(", ")}`);
     const custom = listCustomLayouts();

--- a/src/commands/project.test.ts
+++ b/src/commands/project.test.ts
@@ -78,6 +78,40 @@ describe("handleAddCommand", () => {
     );
   });
 
+  it("rejects name containing '/'", async () => {
+    await expect(handleAddCommand(makeContext({ args: ["team/api", "/tmp/x"] }))).rejects.toThrow(/usage:/);
+    expect(mockAddProject).not.toHaveBeenCalled();
+  });
+
+  it("rejects '..' as name", async () => {
+    await expect(handleAddCommand(makeContext({ args: ["..", "/tmp/x"] }))).rejects.toThrow(/usage:/);
+    expect(mockAddProject).not.toHaveBeenCalled();
+  });
+
+  it("rejects leading '-'", async () => {
+    await expect(handleAddCommand(makeContext({ args: ["-abc", "/tmp/x"] }))).rejects.toThrow(/usage:/);
+    expect(mockAddProject).not.toHaveBeenCalled();
+  });
+
+  it("rejects 65-char name", async () => {
+    await expect(handleAddCommand(makeContext({ args: ["a".repeat(65), "/tmp/x"] }))).rejects.toThrow(/usage:/);
+    expect(mockAddProject).not.toHaveBeenCalled();
+  });
+
+  it("accepts 'my-project_2'", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    await handleAddCommand(makeContext({ args: ["my-project_2", "/tmp/x"] }));
+    expect(mockAddProject).toHaveBeenCalledWith("my-project_2", "/tmp/x");
+    logSpy.mockRestore();
+  });
+
+  it("accepts 'acme.web'", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    await handleAddCommand(makeContext({ args: ["acme.web", "/tmp/x"] }));
+    expect(mockAddProject).toHaveBeenCalledWith("acme.web", "/tmp/x");
+    logSpy.mockRestore();
+  });
+
   it("warns when the path does not exist and registers the expanded path", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});

--- a/src/commands/project.ts
+++ b/src/commands/project.ts
@@ -9,6 +9,7 @@ import {
 } from "../config.js";
 import { focusWorkspace, launch } from "../launcher.js";
 import { promptUser, exitWithUsageHint } from "../utils.js";
+import { validateProjectNameOrExit } from "../validation.js";
 import type { CommandContext } from "./types.js";
 
 function expandHome(path: string): string {
@@ -20,6 +21,7 @@ export async function handleAddCommand({ args }: CommandContext): Promise<void> 
   if (!name || !path) {
     exitWithUsageHint("Usage: summon add <name> <path>");
   }
+  validateProjectNameOrExit(name);
   const resolved = expandHome(path);
   if (!existsSync(resolved)) {
     console.warn(`Warning: path does not exist: ${resolved}`);

--- a/src/launcher.test.ts
+++ b/src/launcher.test.ts
@@ -74,7 +74,7 @@ vi.mock("./script.js", () => ({
 }));
 
 // Import after mocks are set up
-const { launch, resolveConfig, optsToConfigMap, focusWorkspace } = await import("./launcher.js");
+const { launch, resolveConfig, optsToConfigMap, focusWorkspace, resolveProjectName } = await import("./launcher.js");
 const { getConfig, listConfig, listProjects } = await import("./config.js");
 const { existsSync } = await import("node:fs");
 
@@ -3329,5 +3329,39 @@ describe("R5: maximize/float config layering coverage (#190)", () => {
 
     const { opts } = resolveConfig("/tmp/workspace", {});
     expect(opts.float).toBe(true);
+  });
+});
+
+describe("resolveProjectName — basename sanitization", () => {
+  beforeEach(() => {
+    vi.mocked(listProjects).mockReturnValue(new Map<string, string>());
+  });
+
+  it("returns registered name when path matches registry", () => {
+    vi.mocked(listProjects).mockReturnValue(new Map([["api", "/tmp/workspace"]]));
+    expect(resolveProjectName("/tmp/workspace")).toBe("api");
+  });
+
+  it("returns plain basename when it matches PROJECT_NAME_RE", () => {
+    expect(resolveProjectName("/tmp/my-project")).toBe("my-project");
+  });
+
+  it("sanitizes and warns when basename contains spaces", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(resolveProjectName("/tmp/my app")).toBe("my-app");
+    expect(warn).toHaveBeenCalledOnce();
+    warn.mockRestore();
+  });
+
+  it("sanitizes 'my app (v2)' to 'my-app-v2'", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(resolveProjectName("/tmp/my app (v2)")).toBe("my-app-v2");
+    warn.mockRestore();
+  });
+
+  it("falls back to 'project' when basename is all meta-chars", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(resolveProjectName("/tmp/@@@")).toBe("project");
+    warn.mockRestore();
   });
 });

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -20,7 +20,7 @@ import { generateAppleScript, generateTreeAppleScript, generateFocusScript } fro
 import { parseTreeDSL, extractPaneDefinitions, extractPaneCwds, resolveTreeCommands as resolveTreeCmds, buildTreePlan, findPaneByName } from "./tree.js";
 import type { LayoutNode } from "./tree.js";
 import { resolveCommand as resolveCommandPath, promptUser, getErrorMessage, SUMMON_WORKSPACE_ENV, isAccessibilityError, checkAccessibility, isGhosttyInstalled, ACCESSIBILITY_SETTINGS_PATH, ACCESSIBILITY_ENABLE_HINT, ACCESSIBILITY_REQUIRED_MSG } from "./utils.js";
-import { parseIntInRange, parsePositiveFloat, ENV_KEY_RE } from "./validation.js";
+import { parseIntInRange, parsePositiveFloat, ENV_KEY_RE, PROJECT_NAME_RE, sanitizeProjectName } from "./validation.js";
 import { isStarshipInstalled, ensurePresetConfig, getPresetConfigPath } from "./starship.js";
 import { commandExecutable, commandHasShellMeta, replaceCommandExecutable } from "./command-spec.js";
 
@@ -61,13 +61,19 @@ export interface CLIOverrides {
 }
 
 /** Resolve a human-readable project name from a target directory. */
-function resolveProjectName(targetDir: string): string {
+export function resolveProjectName(targetDir: string): string {
   const resolved = resolve(targetDir);
   const projects = listProjects();
   for (const [name, projPath] of projects) {
     if (resolve(projPath) === resolved) return name;
   }
-  return basename(resolved);
+  const derived = basename(resolved);
+  if (PROJECT_NAME_RE.test(derived)) return derived;
+  const sanitized = sanitizeProjectName(derived);
+  console.warn(
+    `Project name "${derived}" contains unsupported characters; using "${sanitized}" for tab title and status tracking.`,
+  );
+  return sanitized;
 }
 
 /** Attempt to focus an existing Ghostty workspace by activating Ghostty. */

--- a/src/script.test.ts
+++ b/src/script.test.ts
@@ -1498,6 +1498,48 @@ describe("status trap", () => {
     const script = generateAppleScript(plan, "/tmp/test", null, undefined, "myapp");
     expect(script).toContain(`printf '%s\\\\n' \\"$$\\" > \\"$HOME/.config/summon/status/myapp.pid\\"`);
   });
+
+  it("writes marker file after pid sidecar (pid-then-marker ordering)", () => {
+    const plan = planLayout();
+    const script = generateAppleScript(plan, "/tmp/test", null, undefined, "myapp");
+    expect(script).toContain(`: > \\"$HOME/.config/summon/status/myapp.active\\"`);
+    // pid must appear before marker in the script
+    const pidIdx = script.indexOf("myapp.pid");
+    const markerIdx = script.indexOf("myapp.active");
+    expect(pidIdx).toBeLessThan(markerIdx);
+  });
+
+  it("routes project name through shellDoubleQuote in pid-then-marker bootstrap", () => {
+    const plan = planLayout();
+    const script = generateAppleScript(plan, "/tmp/test", null, undefined, 'my"proj');
+    // shellDoubleQuote('my"proj') → my\"proj; escapeAppleScript → my\\\"proj (3 backslashes + quote)
+    expect(script).toContain('my\\\\\\"proj.pid');
+    expect(script).toContain('my\\\\\\"proj.active');
+  });
+});
+
+describe("emitCleanupTrap — meta-char payloads", () => {
+  const cases: Array<{ field: string; raw: string; expectedSub: string }> = [
+    { field: "projectName", raw: 'my"app',   expectedSub: 'my\\"app' },
+    // shellDoubleQuote adds one backslash; escapeAppleScript doubles it → 2 backslashes in script
+    { field: "projectName", raw: "my`app`",  expectedSub: "my\\\\`app\\\\`" },
+    { field: "projectName", raw: "my$app",   expectedSub: "my\\\\$app" },
+    { field: "projectName", raw: "my\\app",  expectedSub: "my\\\\\\\\app" },
+    { field: "targetDir",   raw: '/tmp/a"b', expectedSub: 'a\\"b' },
+    // eval "..." context: " → \" (shellDoubleQuote) → \\\" (escapeAppleScript)
+    { field: "onStop",      raw: 'echo "x"', expectedSub: 'echo \\\\\\"x\\\\\\"' },
+  ];
+
+  for (const c of cases) {
+    it(`escapes ${c.field} containing ${JSON.stringify(c.raw)}`, () => {
+      const plan = planLayout();
+      const targetDir = c.field === "targetDir" ? c.raw : "/tmp/p";
+      const projectName = c.field === "projectName" ? c.raw : "proj";
+      const onStop = c.field === "onStop" ? c.raw : undefined;
+      const script = generateAppleScript(plan, targetDir, null, undefined, projectName, onStop);
+      expect(script).toContain(c.expectedSub);
+    });
+  }
 });
 
 describe("generateFocusScript", () => {

--- a/src/script.ts
+++ b/src/script.ts
@@ -3,6 +3,7 @@ import type { LayoutPlan } from "./layout.js";
 import type { TreeLayoutPlan, LayoutNode } from "./tree.js";
 import { firstLeaf, walkLeaves } from "./tree.js";
 import { GHOSTTY_APP_NAME, SUMMON_WORKSPACE_ENV } from "./utils.js";
+import { escapeAppleScript, shellQuote, shellDoubleQuote } from "./shell-escape.js";
 
 // --- AppleScript timing constants (empirically tuned for Ghostty responsiveness) ---
 
@@ -17,26 +18,6 @@ const NEW_WINDOW_DELAY = 0.5;
 
 /** Editor size at which auto-resize is a no-op (50% = equal split already). */
 const AUTO_RESIZE_THRESHOLD = 50;
-
-function escapeAppleScript(s: string): string {
-  return s
-    .replace(/\\/g, "\\\\")
-    .replace(/"/g, '\\"')
-    .replace(/\n/g, "\\n")
-    .replace(/\r/g, "\\r");
-}
-
-/** POSIX single-quote escaping: wrap in single quotes, escape embedded single quotes. */
-function shellQuote(s: string): string {
-  return `'${s.replace(/'/g, "'\\''")}'`;
-}
-
-function shellDoubleQuote(s: string): string {
-  return s.replace(/\\/g, "\\\\")
-    .replace(/"/g, '\\"')
-    .replace(/\$/g, "\\$")
-    .replace(/`/g, "\\`");
-}
 
 // --- Shared helpers ---
 
@@ -114,11 +95,17 @@ function emitCleanupTrap(
   const parts: string[] = [];
 
   if (options?.onStop) {
-    parts.push(`eval "${options.onStop}" 2>/dev/null`);
+    parts.push(`eval "${shellDoubleQuote(options.onStop)}" 2>/dev/null`);
   }
 
   if (options?.targetDir) {
-    parts.push(`summon snapshot save --dir "${options.targetDir}" --project "${projectName}" --layout "${options.layout ?? "unknown"}" 2>/dev/null`);
+    parts.push(
+      `summon snapshot save`
+      + ` --dir "${shellDoubleQuote(options.targetDir)}"`
+      + ` --project "${shellDoubleQuote(projectName)}"`
+      + ` --layout "${shellDoubleQuote(options.layout ?? "unknown")}"`
+      + ` 2>/dev/null`,
+    );
   }
 
   const markerPath = `"$HOME/.config/summon/status/${shellDoubleQuote(projectName)}.active"`;
@@ -135,8 +122,9 @@ function emitRootPanePidBootstrap(
   projectName: string,
 ): void {
   const statusDir = '"$HOME/.config/summon/status"';
-  const pidPath = `"$HOME/.config/summon/status/${shellDoubleQuote(projectName)}.pid"`;
-  sendCommand(rootPaneVar, `mkdir -p ${statusDir} && printf '%s\\n' "$$" > ${pidPath}`);
+  const pidPath    = `"$HOME/.config/summon/status/${shellDoubleQuote(projectName)}.pid"`;
+  const markerPath = `"$HOME/.config/summon/status/${shellDoubleQuote(projectName)}.active"`;
+  sendCommand(rootPaneVar, `mkdir -p ${statusDir} && printf '%s\\n' "$$" > ${pidPath} && : > ${markerPath}`);
 }
 
 /** Emit surface configuration block: working directory, font size, env vars. */

--- a/src/shell-escape.lint.test.ts
+++ b/src/shell-escape.lint.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { describe, it, expect } from "vitest";
+
+const SRC_DIR = new URL(".", import.meta.url).pathname;
+
+function walkTs(dir: string): string[] {
+  const results: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      results.push(...walkTs(full));
+    } else if (entry.endsWith(".ts")) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+const FILES = walkTs(SRC_DIR).filter(
+  (f) =>
+    !f.endsWith(".test.ts") &&
+    !f.endsWith("/shell-escape.ts"),
+);
+
+// Patterns that indicate the line feeds into a shell/AppleScript context
+const DANGER_CONTEXT = /(sh\s+-c|bash\s+-c|osascript|eval\s|input text)/;
+// Patterns that confirm the interpolated value goes through a helper
+const SAFE_CALL = /(shellQuote|shellDoubleQuote|escapeAppleScript)\s*\(/;
+
+describe("shell-escape invariant", () => {
+  it.each(FILES)(
+    "%s — every shell/applescript interpolation routes through a helper",
+    (file) => {
+      const src = readFileSync(file, "utf-8");
+      const lines = src.split("\n");
+      const violations: string[] = [];
+
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i]!;
+        if (!DANGER_CONTEXT.test(line)) continue;
+        if (!/\$\{[^}]+\}/.test(line)) continue;
+        if (SAFE_CALL.test(line)) continue;
+        violations.push(`${relative(SRC_DIR, file)}:${i + 1}: ${line.trim()}`);
+      }
+
+      expect(violations, violations.join("\n")).toEqual([]);
+    },
+  );
+});

--- a/src/shell-escape.test.ts
+++ b/src/shell-escape.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { escapeAppleScript, shellQuote, shellDoubleQuote } from "./shell-escape.js";
+
+describe("escapeAppleScript", () => {
+  it("returns empty string unchanged", () => {
+    expect(escapeAppleScript("")).toBe("");
+  });
+
+  it("leaves already-safe strings unchanged", () => {
+    expect(escapeAppleScript("hello world")).toBe("hello world");
+  });
+
+  it("escapes backslash", () => {
+    expect(escapeAppleScript("a\\b")).toBe("a\\\\b");
+  });
+
+  it("escapes double quote", () => {
+    expect(escapeAppleScript('say "hi"')).toBe('say \\"hi\\"');
+  });
+
+  it("escapes newline", () => {
+    expect(escapeAppleScript("a\nb")).toBe("a\\nb");
+  });
+
+  it("escapes carriage return", () => {
+    expect(escapeAppleScript("a\rb")).toBe("a\\rb");
+  });
+
+  it("escapes composed payload", () => {
+    expect(escapeAppleScript('back\\slash "quote"\nnewline\rreturn')).toBe(
+      'back\\\\slash \\"quote\\"\\nnewline\\rreturn',
+    );
+  });
+});
+
+describe("shellQuote", () => {
+  it("returns empty string as empty single-quoted string", () => {
+    expect(shellQuote("")).toBe("''");
+  });
+
+  it("wraps already-safe string in single quotes", () => {
+    expect(shellQuote("hello")).toBe("'hello'");
+  });
+
+  it("escapes embedded single quote", () => {
+    expect(shellQuote("it's")).toBe("'it'\\''s'");
+  });
+
+  it("handles dollar sign (no escaping needed in single quotes)", () => {
+    expect(shellQuote("$HOME")).toBe("'$HOME'");
+  });
+
+  it("handles backtick (no escaping needed in single quotes)", () => {
+    expect(shellQuote("`pwd`")).toBe("'`pwd`'");
+  });
+
+  it("handles double quote (no escaping needed in single quotes)", () => {
+    expect(shellQuote('"hello"')).toBe("'\"hello\"'");
+  });
+
+  it("escapes composed payload", () => {
+    expect(shellQuote("it's a $test `backtick` \"quote\"")).toBe(
+      "'it'\\''s a $test `backtick` \"quote\"'",
+    );
+  });
+});
+
+describe("shellDoubleQuote", () => {
+  it("returns empty string unchanged", () => {
+    expect(shellDoubleQuote("")).toBe("");
+  });
+
+  it("leaves already-safe strings unchanged", () => {
+    expect(shellDoubleQuote("hello world")).toBe("hello world");
+  });
+
+  it("escapes backslash", () => {
+    expect(shellDoubleQuote("a\\b")).toBe("a\\\\b");
+  });
+
+  it("escapes double quote", () => {
+    expect(shellDoubleQuote('"hello"')).toBe('\\"hello\\"');
+  });
+
+  it("escapes dollar sign", () => {
+    expect(shellDoubleQuote("$HOME")).toBe("\\$HOME");
+  });
+
+  it("escapes backtick", () => {
+    expect(shellDoubleQuote("`pwd`")).toBe("\\`pwd\\`");
+  });
+
+  it("escapes composed payload", () => {
+    expect(shellDoubleQuote('back\\slash "quote" $var `cmd`')).toBe(
+      'back\\\\slash \\"quote\\" \\$var \\`cmd\\`',
+    );
+  });
+});

--- a/src/shell-escape.ts
+++ b/src/shell-escape.ts
@@ -1,0 +1,35 @@
+/**
+ * Shell and AppleScript escape primitives.
+ *
+ * INVARIANT: every outbound interpolation into a shell, AppleScript, or
+ * osascript context must route through one of these helpers. Direct
+ * template-literal interpolation of an untrusted or caller-supplied value
+ * is a bug. The structural test in shell-escape.lint.test.ts enforces this
+ * at CI time.
+ */
+
+/** Escape a value for embedding inside an AppleScript double-quoted string literal. */
+export function escapeAppleScript(s: string): string {
+  return s
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r");
+}
+
+/** POSIX single-quote escaping: wrap in single quotes, escape embedded single quotes. */
+export function shellQuote(s: string): string {
+  return `'${s.replace(/'/g, "'\\''")}'`;
+}
+
+/**
+ * Escape a value for embedding inside a shell double-quoted string ("...").
+ * Escapes \, ", $, and ` so the surrounding "..." context stays intact.
+ */
+export function shellDoubleQuote(s: string): string {
+  return s
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\$/g, "\\$")
+    .replace(/`/g, "\\`");
+}

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -30,10 +30,12 @@ function snapshotPath(project: string): string {
 
 function gitCommand(dir: string, args: string[]): string | null {
   try {
+    const { GIT_DIR: _gd, GIT_WORK_TREE: _gwt, GIT_INDEX_FILE: _gif, ...cleanEnv } = process.env;
     return execFileSync("git", ["-C", dir, ...args], {
       encoding: "utf-8",
       timeout: 5000,
       stdio: ["ignore", "pipe", "ignore"],
+      env: cleanEnv,
     }).trim();
   } catch {
     return null;

--- a/src/status.test.ts
+++ b/src/status.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdirSync, existsSync, readFileSync, writeFileSync, rmSync, unlinkSync } from "node:fs";
+import { mkdirSync, existsSync, readFileSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -63,9 +63,9 @@ describe("writeStatus", () => {
     expect(data.layout).toBe("minimal");
   });
 
-  it("creates .active marker file", () => {
+  it("does NOT create .active marker file (shell bootstrap is authoritative)", () => {
     writeStatus(makeStatus({ project: "myapp" }));
-    expect(existsSync(join(TEST_STATUS_DIR, "myapp.active"))).toBe(true);
+    expect(existsSync(join(TEST_STATUS_DIR, "myapp.active"))).toBe(false);
   });
 
   it("does not create a pid sidecar at write time", () => {
@@ -81,9 +81,11 @@ describe("writeStatus", () => {
 describe("clearStatus", () => {
   it("removes status file and marker", () => {
     writeStatus(makeStatus({ project: "myapp" }));
+    // Simulate shell bootstrap writing marker + pid
+    writeFileSync(join(TEST_STATUS_DIR, "myapp.active"), "");
+    writeFileSync(join(TEST_STATUS_DIR, "myapp.pid"), String(process.pid));
     expect(existsSync(join(TEST_STATUS_DIR, "myapp.json"))).toBe(true);
     expect(existsSync(join(TEST_STATUS_DIR, "myapp.active"))).toBe(true);
-    writeFileSync(join(TEST_STATUS_DIR, "myapp.pid"), String(process.pid));
     clearStatus("myapp");
     expect(existsSync(join(TEST_STATUS_DIR, "myapp.json"))).toBe(false);
     expect(existsSync(join(TEST_STATUS_DIR, "myapp.active"))).toBe(false);
@@ -102,6 +104,8 @@ describe("clearStatus", () => {
 describe("isWorkspaceActive", () => {
   it("returns true when marker and live pid exist", () => {
     writeStatus(makeStatus({ project: "myapp" }));
+    // Simulate shell bootstrap
+    writeFileSync(join(TEST_STATUS_DIR, "myapp.active"), "");
     writeFileSync(join(TEST_STATUS_DIR, "myapp.pid"), String(process.pid));
     expect(isWorkspaceActive("myapp")).toBe(true);
   });
@@ -130,9 +134,11 @@ describe("readStatus", () => {
     expect(() => readStatus("../../etc/evil")).toThrow("Invalid status path");
   });
 
-  it("returns state='active' when marker exists", () => {
+  it("returns state='active' when marker and live pid exist (shell bootstrap simulated)", () => {
     writeStatus(makeStatus({ project: "myapp" }));
+    // Simulate shell bootstrap writing pid then marker
     writeFileSync(join(TEST_STATUS_DIR, "myapp.pid"), String(process.pid));
+    writeFileSync(join(TEST_STATUS_DIR, "myapp.active"), "");
     const result = readStatus("myapp");
     expect(result).not.toBeNull();
     expect(result!.state).toBe("active");
@@ -145,6 +151,7 @@ describe("readStatus", () => {
       throw error;
     });
     writeStatus(makeStatus({ project: "myapp" }));
+    writeFileSync(join(TEST_STATUS_DIR, "myapp.active"), "");
     writeFileSync(join(TEST_STATUS_DIR, "myapp.pid"), "12345");
 
     const result = readStatus("myapp");
@@ -157,8 +164,7 @@ describe("readStatus", () => {
   it("returns state='stopped' when marker missing", () => {
     writeStatus(makeStatus({ project: "myapp" }));
     writeFileSync(join(TEST_STATUS_DIR, "myapp.pid"), String(process.pid));
-    // Remove the marker file manually
-    unlinkSync(join(TEST_STATUS_DIR, "myapp.active"));
+    // marker was never written by writeStatus — shell bootstrap is authoritative
     const result = readStatus("myapp");
     expect(result).not.toBeNull();
     expect(result!.state).toBe("stopped");
@@ -174,6 +180,7 @@ describe("readStatus", () => {
 
   it("treats marker with dead pid as stopped and cleans stale artifacts", () => {
     writeStatus(makeStatus({ project: "myapp" }));
+    writeFileSync(join(TEST_STATUS_DIR, "myapp.active"), "");
     writeFileSync(join(TEST_STATUS_DIR, "myapp.pid"), "999999");
     const result = readStatus("myapp");
     expect(result).not.toBeNull();
@@ -186,6 +193,7 @@ describe("readStatus", () => {
     const pastTime = new Date(Date.now() - 60_000).toISOString();
     writeStatus(makeStatus({ project: "myapp", startedAt: pastTime }));
     writeFileSync(join(TEST_STATUS_DIR, "myapp.pid"), String(process.pid));
+    writeFileSync(join(TEST_STATUS_DIR, "myapp.active"), "");
     const result = readStatus("myapp");
     expect(result!.uptime).not.toBeNull();
     expect(result!.uptime!).toBeGreaterThanOrEqual(59_000);
@@ -193,7 +201,7 @@ describe("readStatus", () => {
 
   it("returns uptime=null for stopped workspaces", () => {
     writeStatus(makeStatus({ project: "myapp" }));
-    unlinkSync(join(TEST_STATUS_DIR, "myapp.active"));
+    // no marker created — shell bootstrap is authoritative, workspace is stopped
     const result = readStatus("myapp");
     expect(result!.uptime).toBeNull();
   });
@@ -220,9 +228,10 @@ describe("readAllStatuses", () => {
     // Write two statuses, one active and one stopped
     writeStatus(makeStatus({ project: "stopped-app", startedAt: new Date(Date.now() - 120_000).toISOString() }));
     writeStatus(makeStatus({ project: "active-app", startedAt: new Date().toISOString() }));
+    // Simulate shell bootstrap for active-app only
     writeFileSync(join(TEST_STATUS_DIR, "active-app.pid"), String(process.pid));
-    // Remove marker for "stopped-app"
-    unlinkSync(join(TEST_STATUS_DIR, "stopped-app.active"));
+    writeFileSync(join(TEST_STATUS_DIR, "active-app.active"), "");
+    // stopped-app has no marker (shell never wrote one)
 
     const results = readAllStatuses();
     expect(results).toHaveLength(2);
@@ -245,8 +254,7 @@ describe("readAllStatuses", () => {
   it("sorts statuses with the same state by newest first", () => {
     writeStatus(makeStatus({ project: "older", startedAt: new Date(Date.now() - 120_000).toISOString() }));
     writeStatus(makeStatus({ project: "newer", startedAt: new Date().toISOString() }));
-    unlinkSync(join(TEST_STATUS_DIR, "older.active"));
-    unlinkSync(join(TEST_STATUS_DIR, "newer.active"));
+    // neither has a marker — both stopped (shell never wrote markers)
 
     const results = readAllStatuses();
 
@@ -266,6 +274,7 @@ describe("cleanStaleStatuses", () => {
   it("preserves active status files", () => {
     writeStatus(makeStatus({ project: "alive" }));
     writeFileSync(join(TEST_STATUS_DIR, "alive.pid"), String(process.pid));
+    writeFileSync(join(TEST_STATUS_DIR, "alive.active"), "");
     const removed = cleanStaleStatuses();
     expect(removed).toBe(0);
     expect(existsSync(join(TEST_STATUS_DIR, "alive.json"))).toBe(true);
@@ -278,6 +287,7 @@ describe("cleanStaleStatuses", () => {
     writeFileSync(join(TEST_STATUS_DIR, "stale1.pid"), "999999");
     writeFileSync(join(TEST_STATUS_DIR, "stale2.pid"), "999999");
     writeFileSync(join(TEST_STATUS_DIR, "alive.pid"), String(process.pid));
+    writeFileSync(join(TEST_STATUS_DIR, "alive.active"), "");
     const removed = cleanStaleStatuses();
     expect(removed).toBe(2);
   });

--- a/src/status.ts
+++ b/src/status.ts
@@ -61,11 +61,16 @@ function pidFilePath(projectName: string): string {
 
 // --- Write ---
 
+/**
+ * Write workspace status JSON. Liveness artifacts (.active marker, .pid sidecar)
+ * are created by the root shell bootstrap after the pid is durable — see
+ * emitRootPanePidBootstrap in src/script.ts. Node never writes the marker; this
+ * eliminates a launch-window race where a concurrent reader would observe
+ * marker-without-pid and GC both artifacts. (2026-04-19 audit #2.)
+ */
 export function writeStatus(status: WorkspaceStatus): void {
   mkdirSync(STATUS_DIR, { recursive: true, mode: 0o700 });
   writeFileSync(statusFilePath(status.project), JSON.stringify(status, null, 2) + "\n", { mode: 0o644 });
-  // Create .active marker file — removed by shell trap on exit
-  writeFileSync(markerFilePath(status.project), "", { mode: 0o644 });
 }
 
 export function clearStatus(projectName: string): void {
@@ -177,10 +182,15 @@ export function readAllStatuses(): ResolvedStatus[] {
 
 export function getGitBranch(directory: string): string | null {
   try {
+    // Unset GIT_DIR/GIT_WORK_TREE so git uses the -C path, not an inherited
+    // hook or worktree environment that would make every directory appear as
+    // the current repo.
+    const { GIT_DIR: _gd, GIT_WORK_TREE: _gwt, GIT_INDEX_FILE: _gif, ...cleanEnv } = process.env;
     const result = execFileSync("git", ["-C", directory, "rev-parse", "--abbrev-ref", "HEAD"], {
       encoding: "utf-8",
       timeout: 5000,
       stdio: ["ignore", "pipe", "ignore"],
+      env: cleanEnv,
     });
     return result.trim() || null;
   } catch {

--- a/src/validation.test.ts
+++ b/src/validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { parseIntInRange, parsePositiveFloat, validateIntFlag, validateFloatFlag, ENV_KEY_RE } from "./validation.js";
+import { parseIntInRange, parsePositiveFloat, validateIntFlag, validateFloatFlag, ENV_KEY_RE, PROJECT_NAME_RE, validateProjectNameOrExit, sanitizeProjectName } from "./validation.js";
 
 describe("parseIntInRange", () => {
   it("returns ok:true with parsed value for valid integer in range", () => {
@@ -151,6 +151,71 @@ describe("ENV_KEY_RE", () => {
     expect(ENV_KEY_RE.test("MY.VAR")).toBe(false);
     expect(ENV_KEY_RE.test("MY VAR")).toBe(false);
     expect(ENV_KEY_RE.test("MY=VAR")).toBe(false);
+  });
+});
+
+describe("PROJECT_NAME_RE", () => {
+  it.each(["a", "abc", "a_b", "a.b", "a-b", "1project", "_p", "a".repeat(64)])(
+    "accepts %s", (s) => expect(PROJECT_NAME_RE.test(s)).toBe(true),
+  );
+  it.each(["", "/", "a/b", "..", ".hidden", "-abc", "a!", "a b", "a".repeat(65)])(
+    "rejects %s", (s) => expect(PROJECT_NAME_RE.test(s)).toBe(false),
+  );
+});
+
+describe("validateProjectNameOrExit", () => {
+  it("does not throw for a valid name", () => {
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => { throw new Error("exit"); });
+    expect(() => validateProjectNameOrExit("my-project_2")).not.toThrow();
+    exitSpy.mockRestore();
+  });
+
+  it("calls exitWithUsageHint for name with '/'", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => { throw new Error("exit:1"); }) as never);
+    expect(() => validateProjectNameOrExit("team/api")).toThrow("exit:1");
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("team/api"));
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it("rejects leading '-'", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => { throw new Error("exit:1"); }) as never);
+    expect(() => validateProjectNameOrExit("-abc")).toThrow("exit:1");
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it("rejects 65-char name", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => { throw new Error("exit:1"); }) as never);
+    expect(() => validateProjectNameOrExit("a".repeat(65))).toThrow("exit:1");
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it("uses custom label in error message", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => { throw new Error("exit:1"); }) as never);
+    expect(() => validateProjectNameOrExit("bad/name", "project name")).toThrow("exit:1");
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("project name"));
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+});
+
+describe("sanitizeProjectName", () => {
+  it.each([
+    ["my app",      "my-app"],
+    ["my app (v2)", "my-app-v2"],
+    ["foo/bar",     "foo-bar"],
+    ["@@@",         "project"],
+    ["a".repeat(100), "a".repeat(64)],
+    [" - foo - ",   "foo"],
+    ["你好",         "project"],
+  ])("sanitizes %s -> %s", (input, expected) => {
+    expect(sanitizeProjectName(input)).toBe(expected);
   });
 });
 

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -10,6 +10,28 @@ import { exitWithUsageHint } from "./utils.js";
 /** Valid environment variable key name: letters, digits, underscores, starting with letter or underscore. */
 export const ENV_KEY_RE = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 
+/** Valid project name: alphanumeric or _ start, alphanumerics and _.- body, 1-64 chars total. */
+export const PROJECT_NAME_RE = /^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,63}$/;
+
+export function validateProjectNameOrExit(name: string, label = "project name"): void {
+  if (!PROJECT_NAME_RE.test(name)) {
+    exitWithUsageHint(
+      `Error: ${label} must start with a letter, digit, or underscore,`
+      + ` contain only letters, digits, and "_.-", and be 1-64 chars.`
+      + ` Got: "${name}".`,
+    );
+  }
+}
+
+export function sanitizeProjectName(raw: string): string {
+  let s = raw.replace(/[^a-zA-Z0-9_.-]/g, "-");
+  s = s.replace(/-+/g, "-");
+  s = s.replace(/^[-.]+|[-.]+$/g, "");
+  if (s.length === 0) return "project";
+  if (s.length > 64) s = s.slice(0, 64);
+  return s;
+}
+
 type ParseResult = {
   ok: true;
   value: number;

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -8,8 +8,8 @@ export default defineConfig({
   format: "esm",
   target: "node18",
   clean: true,
-  sourcemap: false,
+  sourcemap: "inline",
   banner: { js: "#!/usr/bin/env node" },
-  minify: true,
+  minify: false,
   define: { __VERSION__: JSON.stringify(version) },
 });


### PR DESCRIPTION
## Summary

Resolves all 5 findings from the 2026-04-19 deep engineering audit (`docs/research/2026-04-19-deep-engineering-audit.md`).

**Release blockers addressed:**

- **Finding #1 — Shell-escape inconsistency in `emitCleanupTrap`**: Extracted `shellQuote`, `shellDoubleQuote`, `escapeAppleScript` to `src/shell-escape.ts`. Fixed raw interpolations of `projectName`, `targetDir`, and `onStop` in `emitCleanupTrap`. Added structural lint guard (`shell-escape.lint.test.ts`) to catch regressions at CI time.
- **Finding #2 — Status marker race**: Shell is now the sole authority for liveness artifacts. `writeStatus` writes JSON only. `emitRootPanePidBootstrap` writes pid-then-marker (ordering matters — marker signals pid is durable). Eliminates the launch-window race where concurrent `list`/`status`/`monitor` reads would GC both artifacts.
- **Finding #3 — Missing project-name validation in `handleAddCommand`**: Added `PROJECT_NAME_RE`, `validateProjectNameOrExit`, and `sanitizeProjectName` to `validation.ts`. Strict enforcement in `handleAddCommand`; lossy sanitization (with warn) in `resolveProjectName` since directory basenames aren't CLI-controlled.

**Fast-win improvements:**

- **Finding #4 — `--layout` traversal throws stack trace**: `validateLayoutOrExit` wraps `isCustomLayout` in try/catch; path-traversal input now exits via `exitWithUsageHint` instead of an unhandled Node throw.
- **Finding #5 — Minified production build**: `tsup.config.ts` sets `minify: false, sourcemap: "inline"`. Stack traces in bug reports are now actionable.

**Bonus fix**: Cleared `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE` from `execFileSync` env in `getGitBranch` (status.ts) and `gitCommand` (snapshot.ts) to fix pre-existing flakiness where these tests failed in hook environments due to inherited git env vars.

## Test plan

- [ ] `pnpm run typecheck` passes
- [ ] `pnpm run lint` passes
- [ ] `pnpm run test` passes (1425 tests)
- [ ] `pnpm run build` produces readable `dist/index.js` with inline sourcemap
- [ ] Manual: `summon add 'foo/bar' /tmp/x` prints validation error, exits 1
- [ ] Manual: `summon --layout ../../../etc/passwd` prints single-line error, exits 1
- [ ] Manual: launch + concurrent `summon list` — workspace stays `active` once bootstrapped

🤖 Generated with [Claude Code](https://claude.com/claude-code)