### PR TITLE
fix(trust,launcher): resolve trust paths, add --no-project-config, always clean panes

### DIFF
--- a/src/cli/parse.ts
+++ b/src/cli/parse.ts
@@ -24,6 +24,7 @@ export type ParsedValues = {
   "font-size"?: string;
   "on-start"?: string;
   "new-window"?: boolean;
+  "no-project-config"?: boolean;
   fullscreen?: boolean;
   maximize?: boolean;
   float?: boolean;
@@ -98,6 +99,7 @@ Options:
   --font-size <n>             Override font size for workspace panes
   --on-start <cmd>            Run command before workspace creation
   --new-window                Open workspace in a new Ghostty window
+  --no-project-config         Skip the .summon file (do not require trust)
   --fullscreen                Start workspace in fullscreen mode
   --maximize                  Start workspace maximized
   --float                     Float workspace window on top
@@ -304,6 +306,7 @@ const parseOpts = {
     "font-size": { type: "string" },
     "on-start": { type: "string" },
     "new-window": { type: "boolean" },
+    "no-project-config": { type: "boolean" },
     fullscreen: { type: "boolean" },
     maximize: { type: "boolean" },
     float: { type: "boolean" },
@@ -386,6 +389,7 @@ export function buildOverrides(values: ParsedValues): CLIOverrides {
   if (values["font-size"] !== undefined) overrides["font-size"] = values["font-size"];
   if (values["on-start"] !== undefined) overrides["on-start"] = values["on-start"];
   if (values["new-window"] !== undefined) overrides["new-window"] = "true";
+  if (values["no-project-config"] !== undefined) overrides["no-project-config"] = "true";
   if (values.fullscreen !== undefined) overrides.fullscreen = "true";
   if (values.maximize !== undefined) overrides.maximize = "true";
   if (values.float !== undefined) overrides.float = "true";

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -58,6 +58,7 @@ export interface CLIOverrides {
   "font-size"?: string;
   "on-start"?: string;
   "new-window"?: string;
+  "no-project-config"?: string;
   fullscreen?: string;
   maximize?: string;
   float?: string;
@@ -463,7 +464,8 @@ function layerConfigValues(
 
 export function resolveConfig(targetDir: string, cliOverrides: CLIOverrides): ResolvedConfig {
   const projectConfigPath = join(targetDir, ".summon");
-  const project = readKVFile(projectConfigPath);
+  const skipProjectConfig = cliOverrides["no-project-config"] === "true";
+  const project = skipProjectConfig ? new Map<string, string>() : readKVFile(projectConfigPath);
   if (project.size > 0) {
     console.log(`Using project config: ${projectConfigPath}`);
   }
@@ -565,7 +567,7 @@ export function decideCleanRestoredPanes(
   project: Map<string, string>,
   machineConfig: Map<string, string>,
   dryRun: boolean | undefined,
-  projectName?: string,
+  _projectName?: string,
 ): void {
   if (process.env[SUMMON_WORKSPACE_ENV]) return;
   if (opts.newWindow) return;
@@ -584,13 +586,8 @@ export function decideCleanRestoredPanes(
   const count = probePaneCount();
   if (count === null || count <= 1) return;
 
-  // Only auto-clean when the front tab title contains a summon project marker.
-  // This prevents closing non-summon panes that the user has open.
-  if (projectName) {
-    const tabTitle = probeFrontTabTitle();
-    if (tabTitle === null || !tabTitle.includes(`[${projectName}]`)) return;
-  }
-
+  // Clean every pane in the front tab regardless of how it got there.
+  // Users who don't want this can pass --no-clean or --new-window.
   const stale = count - 1;
   const noun = stale === 1 ? "pane" : "panes";
   console.log(`Clearing ${stale} stale ${noun} from previous session...`);
@@ -758,7 +755,7 @@ export async function launch(targetDir: string, cliOverrides?: CLIOverrides): Pr
   // Trust gate: verify the .summon file (if present) is explicitly trusted before
   // reading or acting on any of its values (BE-B1, BE-B2, SE-H1).
   try {
-    assertTrusted(targetDir);
+    assertTrusted(targetDir, { skip: cliOverrides?.["no-project-config"] === "true" });
   } catch (err) {
     if (err instanceof SummonError) {
       console.error(err.message);

--- a/src/trust.ts
+++ b/src/trust.ts
@@ -10,7 +10,7 @@
 
 import { createHash } from "node:crypto";
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { homedir } from "node:os";
 
 /** Error thrown when a .summon file exists but is not trusted. */
@@ -68,7 +68,7 @@ export function isTrusted(dir: string): boolean {
   const hash = hashSummonFile(dir);
   if (hash === null) return true; // no .summon file → trusted by default
   const db = loadTrustDb();
-  const resolvedDir = join(dir); // keep consistent
+  const resolvedDir = resolve(dir);
   return db[resolvedDir] === hash;
 }
 
@@ -80,7 +80,7 @@ export function trustProject(dir: string): void {
   const hash = hashSummonFile(dir);
   if (hash === null) return;
   const db = loadTrustDb();
-  db[dir] = hash;
+  db[resolve(dir)] = hash;
   saveTrustDb(db);
 }
 
@@ -91,7 +91,8 @@ export function trustProject(dir: string): void {
  * Call this early in the launch flow, before any project config values
  * are acted upon.
  */
-export function assertTrusted(targetDir: string): void {
+export function assertTrusted(targetDir: string, opts?: { skip?: boolean }): void {
+  if (opts?.skip) return;
   const summonPath = join(targetDir, ".summon");
   if (!existsSync(summonPath)) return;
   // If we can't determine the hash (e.g., permission error), skip the check
@@ -117,12 +118,13 @@ export function assertTrusted(targetDir: string): void {
  * Prints a confirmation message or an error if no .summon file exists.
  */
 export function handleTrustCommand(dir: string): void {
-  const summonPath = join(dir, ".summon");
+  const resolvedDir = resolve(dir);
+  const summonPath = join(resolvedDir, ".summon");
   if (!existsSync(summonPath)) {
-    console.error(`No .summon file found in: ${dir}`);
+    console.error(`No .summon file found in: ${resolvedDir}`);
     process.exit(1);
   }
-  trustProject(dir);
-  console.log(`Trusted .summon file in: ${dir}`);
-  console.log(`SHA-256: ${hashSummonFile(dir)}`);
+  trustProject(resolvedDir);
+  console.log(`Trusted .summon file in: ${resolvedDir}`);
+  console.log(`SHA-256: ${hashSummonFile(resolvedDir)}`);
 }


### PR DESCRIPTION
## Summary
- `summon trust .` now stores the absolute path so trust persists across launches (previously stored the literal `"."` and never matched the resolved target dir).
- `--no-project-config` flag is implemented for real — was advertised in the trust error message but never wired into the parser.
- Pane clearing in `decideCleanRestoredPanes` no longer gates on the front-tab title containing `[<projectName>]`. Re-launching a project from any tab now clears the existing panes and renders the fresh layout. `--no-clean` and `--new-window` remain the escape hatches.

## Test plan
- [x] `pnpm test` (1732 passing)
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] Manual: `summon trust .` then `summon coach --dry-run` resolves project config without re-prompting

🤖 Generated with [Claude Code](https://claude.com/claude-code)