### PR TITLE
release: v1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.2] - 2026-05-10
+
+### Fixed
+
+- `summon trust .` now stores the absolute project path so trust persists across
+  launches. Previously the literal `"."` was recorded, never matching the resolved
+  target dir on subsequent runs.
+- Pane cleanup on launch no longer requires the front tab title to contain the
+  project marker. Re-launching a project from any tab clears the existing panes
+  and renders the fresh layout. `--no-clean` and `--new-window` remain the
+  escape hatches.
+
+### Added
+
+- `--no-project-config` flag — skips reading and trust-checking the `.summon`
+  file. The flag was previously advertised in the trust error message but never
+  wired into the parser.
+
 ## [1.4.1] - 2026-05-09
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "summon-ws",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Launch configurable multi-pane Ghostty workspaces with one command",
   "type": "module",
   "packageManager": "pnpm@10.29.2",


### PR DESCRIPTION
## [1.4.2] - 2026-05-10

### Fixed

- \`summon trust .\` now stores the absolute project path so trust persists across launches. Previously the literal \`"."\` was recorded, never matching the resolved target dir on subsequent runs.
- Pane cleanup on launch no longer requires the front tab title to contain the project marker. Re-launching a project from any tab clears the existing panes and renders the fresh layout. \`--no-clean\` and \`--new-window\` remain the escape hatches.

### Added

- \`--no-project-config\` flag — skips reading and trust-checking the \`.summon\` file. The flag was previously advertised in the trust error message but never wired into the parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)