### PR TITLE
fix(trust): path normalization + fail-closed on IO errors

### DIFF
--- a/src/trust.test.ts
+++ b/src/trust.test.ts
@@ -6,12 +6,14 @@ const mockExistsSync = vi.fn();
 const mockReadFileSync = vi.fn();
 const mockWriteFileSync = vi.fn();
 const mockMkdirSync = vi.fn();
+const mockRealpathSync = vi.fn();
 
 vi.mock("node:fs", () => ({
   existsSync: (path: string) => mockExistsSync(path),
   readFileSync: (path: string, encoding: string) => mockReadFileSync(path, encoding),
   writeFileSync: (path: string, data: string, encoding: string) => mockWriteFileSync(path, data, encoding),
   mkdirSync: (path: string, opts: unknown) => mockMkdirSync(path, opts),
+  realpathSync: (path: string) => mockRealpathSync(path),
 }));
 
 // Mock node:os
@@ -31,6 +33,8 @@ function sha256(content: string): string {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Default: realpathSync resolves to the same path (simulates absolute paths that exist)
+  mockRealpathSync.mockImplementation((p: string) => p);
 });
 
 describe("SummonError", () => {
@@ -285,6 +289,87 @@ describe("assertTrusted", () => {
     });
 
     expect(() => assertTrusted("/some/dir")).not.toThrow();
+  });
+});
+
+describe("path normalization", () => {
+  it("trusting via relative path (.) is found when queried with absolute path", () => {
+    const content = "editor = vim\n";
+    const hash = sha256(content);
+    const absPath = "/home/testuser/myproject";
+
+    // realpathSync resolves "." to the absolute path
+    mockRealpathSync.mockImplementation((p: string) => {
+      if (p === ".") return absPath;
+      return p;
+    });
+
+    mockExistsSync.mockImplementation((p: string) => {
+      if (p.endsWith(".summon")) return true;
+      if (p === TRUST_FILE) return false; // no existing trust.json before write
+      return false;
+    });
+    mockReadFileSync.mockImplementation((p: string) => {
+      if (p.endsWith(".summon")) return content;
+      // After trust is written, simulate reading it back
+      return JSON.stringify({ [absPath]: hash });
+    });
+
+    // Trust via relative path "."
+    trustProject(".");
+
+    // Verify the DB was written with the absolute key
+    const written = mockWriteFileSync.mock.calls[0]![1] as string;
+    const parsed = JSON.parse(written) as Record<string, string>;
+    expect(parsed[absPath]).toBe(hash);
+    expect(parsed["."]).toBeUndefined();
+
+    // Now isTrusted with the absolute path should return true
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockImplementation((p: string) => {
+      if (p.endsWith(".summon")) return content;
+      return JSON.stringify({ [absPath]: hash });
+    });
+
+    expect(isTrusted(absPath)).toBe(true);
+  });
+
+  it("trusting via absolute path is found when queried with relative path (.)", () => {
+    const content = "editor = vim\n";
+    const hash = sha256(content);
+    const absPath = "/home/testuser/myproject";
+
+    // realpathSync normalizes both absolute path and "." to absPath
+    mockRealpathSync.mockImplementation((p: string) => {
+      if (p === "." || p === absPath) return absPath;
+      return p;
+    });
+
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockImplementation((p: string) => {
+      if (p.endsWith(".summon")) return content;
+      return JSON.stringify({ [absPath]: hash });
+    });
+
+    // isTrusted with "." should normalize to absPath and find the trust entry
+    expect(isTrusted(".")).toBe(true);
+  });
+});
+
+describe("assertTrusted fail-closed", () => {
+  it("throws when isTrusted throws a non-ENOENT error (e.g. EACCES on .summon file)", () => {
+    mockExistsSync.mockImplementation((p: string) => {
+      if (p.endsWith(".summon")) return true;
+      return false; // trust.json doesn't exist
+    });
+
+    // Simulate a permission error when reading the .summon file itself
+    const permError = Object.assign(new Error("Permission denied"), { code: "EACCES" });
+    mockReadFileSync.mockImplementation((_p: string) => {
+      throw permError;
+    });
+
+    expect(() => assertTrusted("/some/dir")).toThrow(/Cannot verify trust/);
   });
 });
 

--- a/src/trust.ts
+++ b/src/trust.ts
@@ -9,8 +9,8 @@
  */
 
 import { createHash } from "node:crypto";
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, readFileSync, writeFileSync, mkdirSync, realpathSync } from "node:fs";
+import { join, resolve } from "node:path";
 import { homedir } from "node:os";
 
 /** Error thrown when a .summon file exists but is not trusted. */
@@ -65,11 +65,11 @@ export function hashSummonFile(dir: string): string | null {
  * current file hash matches the stored hash.
  */
 export function isTrusted(dir: string): boolean {
+  const normalizedDir = (() => { try { return realpathSync(dir); } catch { return resolve(dir); } })();
   const hash = hashSummonFile(dir);
   if (hash === null) return true; // no .summon file → trusted by default
   const db = loadTrustDb();
-  const resolvedDir = join(dir); // keep consistent
-  return db[resolvedDir] === hash;
+  return db[normalizedDir] === hash;
 }
 
 /**
@@ -77,10 +77,11 @@ export function isTrusted(dir: string): boolean {
  * No-op if the .summon file does not exist.
  */
 export function trustProject(dir: string): void {
+  const normalizedDir = (() => { try { return realpathSync(dir); } catch { return resolve(dir); } })();
   const hash = hashSummonFile(dir);
   if (hash === null) return;
   const db = loadTrustDb();
-  db[dir] = hash;
+  db[normalizedDir] = hash;
   saveTrustDb(db);
 }
 
@@ -100,9 +101,13 @@ export function assertTrusted(targetDir: string): void {
   let trusted: boolean;
   try {
     trusted = isTrusted(targetDir);
-  } catch {
-    // Unable to compute or read trust state — fail open (do not block).
-    return;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === undefined || code === "ENOENT") return; // no .summon file or non-OS error → nothing to check
+    throw new Error(
+      "Cannot verify trust for this project; run 'summon trust .' to re-establish",
+      { cause: err },
+    );
   }
   if (trusted) return;
 


### PR DESCRIPTION
Closes #356, #380, #393

- realpathSync normalization in trustProject/isTrusted
- fail-closed on non-ENOENT errors in assertTrusted
- 3 new tests