### PR TITLE
fix(script): remove dead cache + module-global mutable state; clean dead overload

### DIFF
--- a/src/script.test.ts
+++ b/src/script.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { generateAppleScript, generateTreeAppleScript, generateFocusScript } from "./script.js";
 import { planLayout, getPreset } from "./layout.js";
 import { collectLeaves, buildTreePlan } from "./tree.js";
@@ -1711,84 +1711,29 @@ describe("generateFocusScript", () => {
   });
 });
 
-// --- AR-L5: options object API ---
+// AR-L5 options object overload has been removed (AR-M2 #373) — the half-finished
+// refactor was dead code; all callers in launcher.ts use the positional form.
 
-describe("generateAppleScript — options object form (AR-L5)", () => {
-  it("accepts a single options object and produces the same output as positional form", () => {
-    const plan = planLayout({ editor: "vim" });
-    const scriptFromOptions = generateAppleScript({
-      plan,
-      targetDir: "/tmp/project",
-      starshipConfigPath: null,
-      envVars: { NODE_ENV: "test" },
-      projectName: "myapp",
-      onStop: "echo done",
-    });
+// --- PE-L4 (removed): tab-title escapeAppleScript was previously memoized with module-global
+// state (_tabTitleEscapeCache). The cache has been removed (fixes BE-H2 + BE-L2) — script.ts
+// now calls escapeAppleScript(title) directly on each invocation to preserve the pure-function
+// architecture invariant documented in CLAUDE.md.
 
-    expect(scriptFromOptions).toContain('tell application "Ghostty"');
-    expect(scriptFromOptions).toContain("new surface configuration");
-    expect(scriptFromOptions).toContain("myapp");
-    expect(scriptFromOptions).toContain("NODE_ENV=test");
-    expect(scriptFromOptions).toContain("echo done");
-    expect(scriptFromOptions).toContain("end tell");
+describe("escapeTabTitle — no module-global mutable state (BE-H2, BE-L2)", () => {
+  it("repeated generateAppleScript calls with the same tab title produce identical output (cache not needed)", () => {
+    const plan = planLayout(getPreset("full"));
+    const script1 = generateAppleScript(plan, "/tmp/proj", null, undefined, "stable-title");
+    const script2 = generateAppleScript(plan, "/tmp/proj", null, undefined, "stable-title");
+    // Pure function: same inputs → same outputs, no state required
+    expect(script1).toBe(script2);
+    expect(script1).toContain("set_tab_title:[stable-title]");
   });
 
-  it("options object with only required fields works (optional fields omitted)", () => {
+  it("tab title is correctly escaped on each call without caching", () => {
     const plan = planLayout();
-    const script = generateAppleScript({ plan, targetDir: "/tmp/bare" });
-    expect(script).toContain('tell application "Ghostty"');
-    expect(script).toContain("/tmp/bare");
-    expect(script).toContain("end tell");
-  });
-
-  it("options object result matches positional-arg result exactly", () => {
-    const plan = planLayout({ editor: "nvim" });
-    const starshipPath = "/usr/local/starship.toml";
-    const envVars = { DEBUG: "1" };
-    const projectName = "testproj";
-    const onStop = "cleanup.sh";
-
-    const fromOptions = generateAppleScript({
-      plan,
-      targetDir: "/tmp/mydir",
-      starshipConfigPath: starshipPath,
-      envVars,
-      projectName,
-      onStop,
-    });
-    const fromPositional = generateAppleScript(plan, "/tmp/mydir", starshipPath, envVars, projectName, onStop);
-
-    expect(fromOptions).toBe(fromPositional);
-  });
-});
-
-// --- PE-L4: tab-title escapeAppleScript memoization ---
-
-describe("escapeAppleScript memoization (PE-L4)", () => {
-  beforeEach(() => {
-    vi.resetModules();
-  });
-
-  it("escapeAppleScript is called only once across two generateAppleScript calls with the same tab title", async () => {
-    // Dynamically import so the spy can intercept the module's live binding
-    const escapeModule = await import("./shell-escape.js");
-    const spy = vi.spyOn(escapeModule, "escapeAppleScript");
-
-    const { generateAppleScript: gas } = await import("./script.js");
-    const { planLayout: pl } = await import("./layout.js");
-
-    const plan = pl(getPreset("full"));
-    const title = "[stable-title]";
-
-    // Call twice with the identical tab title — memoization should deduplicate
-    gas({ plan, targetDir: "/tmp/proj", projectName: "stable-title" });
-    gas({ plan, targetDir: "/tmp/proj", projectName: "stable-title" });
-
-    // With a single-slot cache, escapeAppleScript(title) should be called only once
-    const tabTitleCalls = spy.mock.calls.filter(([arg]) => arg === title);
-    expect(tabTitleCalls.length).toBe(1);
-
-    spy.mockRestore();
+    const script = generateAppleScript(plan, "/tmp/proj", null, undefined, 'my"app');
+    // projectName wraps in brackets: [my"app] → escapeAppleScript → [my\"app]
+    expect(script).toContain('set_tab_title:[my\\"app]');
   });
 });
 

--- a/src/script.ts
+++ b/src/script.ts
@@ -185,18 +185,9 @@ function emitRootPaneCommand(
   }
 }
 
-/** Single-slot memoization cache for tab-title escaping (PE-L4). */
-const tabTitleEscapeCache: { input: string; output: string } | null = null;
-let _tabTitleEscapeCache: { input: string; output: string } | null = tabTitleEscapeCache;
-
-/** Escape a tab title, using a single-slot cache for stability across repeated calls. */
+/** Escape a tab title for use in an AppleScript action string. */
 function escapeTabTitle(title: string): string {
-  if (_tabTitleEscapeCache !== null && _tabTitleEscapeCache.input === title) {
-    return _tabTitleEscapeCache.output;
-  }
-  const output = escapeAppleScript(title);
-  _tabTitleEscapeCache = { input: title, output };
-  return output;
+  return escapeAppleScript(title);
 }
 
 /** Emit pane and tab titles block. */
@@ -474,61 +465,10 @@ export function generateFocusScript(tabTitle: string): string {
 // projectName, onStop). Any new option must be plumbed through both functions. Consider
 // extracting shared option handling into a common helper to reduce duplication.
 
-/** Options object form for generateAppleScript (AR-L5). */
-export interface GenerateAppleScriptOptions {
-  plan: LayoutPlan;
-  targetDir: string;
-  starshipConfigPath?: string | null;
-  envVars?: Record<string, string>;
-  projectName?: string;
-  onStop?: string;
-}
-
 /**
  * Generate AppleScript for a traditional (LayoutPlan) workspace.
- * Accepts either a single options object or positional arguments (backward-compatible).
  */
-export function generateAppleScript(opts: GenerateAppleScriptOptions): string;
-export function generateAppleScript(plan: LayoutPlan, targetDir: string, starshipConfigPath?: string | null, envVars?: Record<string, string>, projectName?: string, onStop?: string): string;
-export function generateAppleScript(
-  planOrOpts: LayoutPlan | GenerateAppleScriptOptions,
-  targetDir?: string,
-  starshipConfigPath?: string | null,
-  envVars?: Record<string, string>,
-  projectName?: string,
-  onStop?: string,
-): string {
-  // Resolve arguments from options object or positional form
-  let plan: LayoutPlan;
-  let resolvedTargetDir: string;
-  let resolvedStarshipConfigPath: string | null | undefined;
-  let resolvedEnvVars: Record<string, string> | undefined;
-  let resolvedProjectName: string | undefined;
-  let resolvedOnStop: string | undefined;
-
-  if ("plan" in planOrOpts && "targetDir" in planOrOpts) {
-    // Options object form
-    const opts = planOrOpts as GenerateAppleScriptOptions;
-    plan = opts.plan;
-    resolvedTargetDir = opts.targetDir;
-    resolvedStarshipConfigPath = opts.starshipConfigPath;
-    resolvedEnvVars = opts.envVars;
-    resolvedProjectName = opts.projectName;
-    resolvedOnStop = opts.onStop;
-  } else {
-    // Positional form
-    plan = planOrOpts as LayoutPlan;
-    resolvedTargetDir = targetDir!;
-    resolvedStarshipConfigPath = starshipConfigPath;
-    resolvedEnvVars = envVars;
-    resolvedProjectName = projectName;
-    resolvedOnStop = onStop;
-  }
-
-  return generateAppleScriptImpl(plan, resolvedTargetDir, resolvedStarshipConfigPath, resolvedEnvVars, resolvedProjectName, resolvedOnStop);
-}
-
-function generateAppleScriptImpl(plan: LayoutPlan, targetDir: string, starshipConfigPath?: string | null, envVars?: Record<string, string>, projectName?: string, onStop?: string): string {
+export function generateAppleScript(plan: LayoutPlan, targetDir: string, starshipConfigPath?: string | null, envVars?: Record<string, string>, projectName?: string, onStop?: string): string {
   const lines: string[] = [];
   const titles: Array<[string, string]> = [];
   const interactiveShellPanes: string[] = [];


### PR DESCRIPTION
Closes #363, #374, #373

- Remove dead const tabTitleEscapeCache = null
- Remove _tabTitleEscapeCache module-global; call escapeAppleScript directly
- Remove unused GenerateAppleScriptOptions overload