### PR TITLE
fix(cli): trust in registry, help accuracy, lazy imports, completions

### DIFF
--- a/src/cli/parse.test.ts
+++ b/src/cli/parse.test.ts
@@ -267,6 +267,67 @@ describe("help output", () => {
   });
 });
 
+// --- UX-H1 + FE-H2: trust in help text ---
+
+describe("trust command in help and subcommand help", () => {
+  it("includes 'trust' in the main help text (FE-H2 #359)", () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    showHelp();
+
+    const output = logSpy.mock.calls.map(c => c[0]).join("\n");
+    expect(output).toContain("trust");
+    logSpy.mockRestore();
+  });
+
+  it("has subcommand help entry for 'trust' (FE-H2 #359)", () => {
+    expect(hasSubcommandHelp("trust")).toBe(true);
+  });
+});
+
+// --- UX-H3: --once warning allowlist ---
+
+describe("--once warning allowlist (UX-H3 #372)", () => {
+  it("does not emit warning for 'status' subcommand with --once (status is allowlisted)", () => {
+    // The warning guard is in index.ts, not parse.ts, but we test the allowlist here
+    // via ONCE_ALLOWED_SUBCOMMANDS export if available, otherwise we test the behavior
+    // We verify status is in the list of subcommands that legitimately use --once
+    expect(hasSubcommandHelp("status")).toBe(true);
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    showSubcommandHelp("status");
+    const output = logSpy.mock.calls.map(c => c[0]).join("\n");
+    expect(output).toContain("--once");
+    logSpy.mockRestore();
+  });
+});
+
+// --- UX-M3: unknown flag error message ---
+
+describe("unknown flag error message (UX-M3 #396)", () => {
+  it("emits an actionable error for unknown flags instead of raw parseArgs text", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(() => parseCli(["--bogus-flag"])).toThrow("usage:");
+    const allErrors = errorSpy.mock.calls.map(c => c[0]).join("\n");
+    expect(allErrors).toMatch(/Unknown flag.*--bogus-flag/i);
+    expect(allErrors).toContain("summon --help");
+    errorSpy.mockRestore();
+  });
+});
+
+// --- UX-M8: fish in completions subcommand help ---
+
+describe("fish completions in subcommand help (UX-M8 #397)", () => {
+  it("mentions fish shell in completions subcommand help", () => {
+    expect(hasSubcommandHelp("completions")).toBe(true);
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    showSubcommandHelp("completions");
+    const output = logSpy.mock.calls.map(c => c[0]).join("\n");
+    expect(output).toContain("fish");
+    logSpy.mockRestore();
+  });
+});
+
 // --- AR-L3: bounds-checked subcommand help ---
 
 describe("showSubcommandHelp — bounds check (AR-L3)", () => {

--- a/src/cli/parse.ts
+++ b/src/cli/parse.ts
@@ -88,6 +88,7 @@ TOOLS
   summon doctor               Check Ghostty config for recommended settings
   summon doctor --fix         Auto-add missing recommended settings (backs up first)
   summon completions <shell>  Generate shell completion script (zsh, bash, fish)
+  summon trust [path]         Trust the .summon file in the given directory (default: current)
 
 Options:
   -h, --help                  Show this help message
@@ -163,7 +164,6 @@ Examples:
   summon freeze mysetup           Save current config as reusable layout
 
 Run 'summon <command> --help' for details on each command.
-Run 'summon help <topic>' for topic-specific help.
 `.trim();
 
 const SUBCOMMAND_HELP: Record<string, string> = {
@@ -197,11 +197,12 @@ You can also set individual values with: summon set <key> <value>`,
 
   completions: `Usage: summon completions <shell>
 
-Generate shell completion script. Supported shells: zsh, bash.
+Generate shell completion script. Supported shells: zsh, bash, fish.
 
 Setup (add to your shell config):
   zsh:   eval "$(summon completions zsh)"
-  bash:  eval "$(summon completions bash)"`,
+  bash:  eval "$(summon completions bash)"
+  fish:  eval (summon completions fish | psub)`,
 
   status: `Usage: summon status [--once]
 
@@ -312,6 +313,18 @@ Actions:
 
 Session names must start with a letter and contain only letters, digits, hyphens, and underscores.
 Reserved names: add, remove, list, show, all.`,
+
+  trust: `Usage: summon trust [path]
+
+Mark the .summon file in the given directory as trusted.
+Defaults to the current directory if no path is given.
+
+Summon refuses to execute .summon files from untrusted directories.
+Running this command approves the file's current contents.
+
+Example:
+  summon trust         Trust .summon in current directory
+  summon trust ~/app   Trust .summon in ~/app`,
 };
 
 const parseOpts = {
@@ -356,9 +369,15 @@ function safeParse(args: string[]): { values: ParsedValues; positionals: string[
     };
   } catch (err) {
     const msg = getErrorMessage(err);
-    console.error(`Error: ${msg}`);
-    if (msg.includes("ambiguous")) {
-      console.error("Tip: To pass a value starting with '-', use '--flag=-value' syntax.");
+    // UX-M3 (#396): transform raw parseArgs "Unknown option" into actionable message
+    const unknownMatch = msg.match(/Unknown option\s+'?(--[A-Za-z0-9-]+)/);
+    if (unknownMatch?.[1]) {
+      console.error(`Error: Unknown flag '${unknownMatch[1]}'. Run 'summon --help' to see available flags.`);
+    } else {
+      console.error(`Error: ${msg}`);
+      if (msg.includes("ambiguous")) {
+        console.error("Tip: To pass a value starting with '-', use '--flag=-value' syntax.");
+      }
     }
     exitWithUsageHint();
   }

--- a/src/commands/layout.test.ts
+++ b/src/commands/layout.test.ts
@@ -152,7 +152,8 @@ describe("handleLayoutCommand", () => {
     expect(logSpy).toHaveBeenCalledWith("    ┌──┐");
     expect(logSpy).toHaveBeenCalledWith("    └──┘");
     expect(logSpy).toHaveBeenCalledWith("    Config: layout=pair");
-    expect(logSpy).toHaveBeenCalledWith("    Panes:  main=\x1b[36mnvim\x1b[0m");
+    // FE-H1 (#358): cyan() helper used instead of raw ANSI; no-color in test env → plain text
+    expect(logSpy).toHaveBeenCalledWith("    Panes:  main=nvim");
     expect(logSpy).toHaveBeenCalledWith("    Tree:   bad-tree");
   });
 
@@ -163,7 +164,8 @@ describe("handleLayoutCommand", () => {
 
     await handleLayoutCommand(makeContext({ args: ["list"] }));
 
-    expect(logSpy).toHaveBeenCalledWith("  \x1b[1morphan\x1b[0m");
+    // FE-H1 (#358): bold() helper used instead of raw ANSI; no-color in test env → plain text
+    expect(logSpy).toHaveBeenCalledWith("  orphan");
   });
 
   it("lists pane definitions when a layout has panes but no tree", async () => {
@@ -176,7 +178,8 @@ describe("handleLayoutCommand", () => {
 
     await handleLayoutCommand(makeContext({ args: ["list"] }));
 
-    expect(logSpy).toHaveBeenCalledWith("    Panes:  main=\x1b[36mnvim\x1b[0m  shell=\x1b[36mzsh\x1b[0m");
+    // FE-H1 (#358): cyan() helper used instead of raw ANSI; no-color in test env → plain text
+    expect(logSpy).toHaveBeenCalledWith("    Panes:  main=nvim  shell=zsh");
   });
 
   it("shows custom layout contents", async () => {
@@ -292,5 +295,27 @@ describe("handleLayoutCommand", () => {
     await expect(handleLayoutCommand(makeContext({ args: ["wat"] }))).rejects.toThrow(
       "usage:Error: Unknown layout action: wat\nUsage: summon layout <create|save|list|show|delete|edit> [name]",
     );
+  });
+
+  // FE-M4 (#388): --names flag outputs one bare name per line
+  it("outputs one bare layout name per line when --names flag is passed (FE-M4 #388)", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    mockListCustomLayouts.mockReturnValue(["team", "minimal", "devops"]);
+
+    await handleLayoutCommand(makeContext({ args: ["list", "--names"] }));
+
+    const calls = logSpy.mock.calls.map(c => c[0] as string);
+    expect(calls).toEqual(["team", "minimal", "devops"]);
+    logSpy.mockRestore();
+  });
+
+  it("outputs nothing for --names when no custom layouts exist (FE-M4 #388)", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    mockListCustomLayouts.mockReturnValue([]);
+
+    await handleLayoutCommand(makeContext({ args: ["list", "--names"] }));
+
+    expect(logSpy).not.toHaveBeenCalled();
+    logSpy.mockRestore();
   });
 });

--- a/src/commands/layout.ts
+++ b/src/commands/layout.ts
@@ -12,6 +12,7 @@ import { isPresetName } from "../layout.js";
 import { SAFE_COMMAND_RE, exitWithUsageHint } from "../utils.js";
 import { parseTreeDSL } from "../tree.js";
 import { renderLayoutPreview } from "../ui/layout-preview.js";
+import { bold, cyan } from "../ui/ansi.js";
 import type { CommandContext } from "./types.js";
 import {
   layoutNotFoundOrExit,
@@ -20,7 +21,12 @@ import {
 } from "./layout-support.js";
 
 export async function handleLayoutCommand({ args }: CommandContext): Promise<void> {
-  const [action, layoutName] = args;
+  // FE-M4 (#388): --names is a sub-flag for "layout list", passed as an extra positional arg
+  const namesIndex = args.indexOf("--names");
+  const namesFlag = namesIndex !== -1;
+  // Remove --names from args for further processing
+  const cleanArgs = namesFlag ? args.filter(a => a !== "--names") : args;
+  const [action, layoutName] = cleanArgs;
   if (!action) {
     exitWithUsageHint("Usage: summon layout <create|save|list|show|delete|edit> [name]");
   }
@@ -52,6 +58,15 @@ export async function handleLayoutCommand({ args }: CommandContext): Promise<voi
 
     case "list": {
       const layouts = listCustomLayouts();
+
+      // FE-M4 (#388): --names outputs one bare name per line for use in shell completions
+      if (namesFlag) {
+        for (const name of layouts) {
+          console.log(name);
+        }
+        return;
+      }
+
       if (layouts.length === 0) {
         console.log("No custom layouts saved. Use: summon layout save <name>");
         return;
@@ -61,7 +76,7 @@ export async function handleLayoutCommand({ args }: CommandContext): Promise<voi
       for (const [index, name] of layouts.entries()) {
         const data = readCustomLayout(name);
         if (!data) {
-          console.log(`  \x1b[1m${name}\x1b[0m`);
+          console.log(`  ${bold(name)}`);
         } else {
           const paneMap = new Map<string, string>();
           let tree = "";
@@ -76,7 +91,7 @@ export async function handleLayoutCommand({ args }: CommandContext): Promise<voi
             }
           }
 
-          console.log(`  \x1b[1m${name}\x1b[0m`);
+          console.log(`  ${bold(name)}`);
           if (tree && paneMap.size > 0) {
             try {
               const node = parseTreeDSL(tree);
@@ -86,12 +101,12 @@ export async function handleLayoutCommand({ args }: CommandContext): Promise<voi
                 console.log(`    ${line}`);
               }
             } catch {
-              const paneList = [...paneMap.entries()].map(([key, value]) => `${key}=\x1b[36m${value}\x1b[0m`);
+              const paneList = [...paneMap.entries()].map(([key, value]) => `${key}=${cyan(value)}`);
               console.log(`    Panes:  ${paneList.join("  ")}`);
               console.log(`    Tree:   ${tree}`);
             }
           } else if (paneMap.size > 0) {
-            const paneList = [...paneMap.entries()].map(([key, value]) => `${key}=\x1b[36m${value}\x1b[0m`);
+            const paneList = [...paneMap.entries()].map(([key, value]) => `${key}=${cyan(value)}`);
             console.log(`    Panes:  ${paneList.join("  ")}`);
           }
           if (other.length > 0) {

--- a/src/commands/project.test.ts
+++ b/src/commands/project.test.ts
@@ -121,7 +121,22 @@ describe("handleAddCommand", () => {
 
     expect(mockAddProject).toHaveBeenCalledWith("demo", "/Users/tester/code/demo");
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Warning: path does not exist: /Users/tester/code/demo"));
-    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("Registered: demo"));
+    // UX-M1 (#395): message should indicate warning, not plain success
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("Registered with warning"));
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  it("shows plain success message when path exists (UX-M1 #395)", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    mockExistsSync.mockReturnValue(true);
+
+    await handleAddCommand(makeContext({ args: ["demo", "/tmp/x"] }));
+
+    const msg = logSpy.mock.calls.map(c => c[0] as string).join("\n");
+    expect(msg).toContain("Registered: demo");
+    expect(msg).not.toContain("warning");
+    logSpy.mockRestore();
   });
 });
 

--- a/src/commands/project.ts
+++ b/src/commands/project.ts
@@ -37,11 +37,17 @@ export async function handleAddCommand({ args }: CommandContext): Promise<void> 
   }
   validateProjectNameOrExit(name);
   const resolved = expandHome(path);
-  if (!existsSync(resolved)) {
+  const pathExists = existsSync(resolved);
+  if (!pathExists) {
     console.warn(`${sym.warn} Warning: path does not exist: ${resolved}`);
   }
   addProject(name, resolved);
-  console.log(`${sym.ok} Registered: ${name} → ${resolved}`);
+  // UX-M1 (#395): distinguish between clean registration and registration with a warning
+  if (pathExists) {
+    console.log(`${sym.ok} Registered: ${name} → ${resolved}`);
+  } else {
+    console.log(`${sym.warn} Registered with warning: ${name} → ${resolved} (path does not exist)`);
+  }
 }
 
 export async function handleRemoveCommand({ args }: CommandContext): Promise<void> {

--- a/src/commands/trust.ts
+++ b/src/commands/trust.ts
@@ -1,0 +1,8 @@
+import { trustProject } from "../trust.js";
+import type { CommandContext } from "./types.js";
+
+export async function handleTrustCommand({ args }: CommandContext): Promise<void> {
+  const dir = args[0] ?? ".";
+  trustProject(typeof dir === "string" ? dir : ".");
+  console.log(`✓ Trusted: ${dir}`);
+}

--- a/src/completions.test.ts
+++ b/src/completions.test.ts
@@ -317,6 +317,42 @@ describe("session subcommand completions", () => {
   });
 });
 
+describe("trust subcommand in completions (FE-H2 #359)", () => {
+  test("zsh completions include trust subcommand", () => {
+    const result = generateZshCompletion();
+    expect(result).toContain("trust");
+  });
+
+  test("bash completions include trust subcommand", () => {
+    const result = generateBashCompletion();
+    expect(result).toContain("trust");
+  });
+
+  test("fish completions include trust subcommand", () => {
+    const result = generateFishCompletion();
+    expect(result).toContain("trust");
+  });
+});
+
+describe("layout list --names for completions (FE-M4 #388)", () => {
+  test("bash completions use 'summon layout list --names' for layout presets", () => {
+    const result = generateBashCompletion();
+    expect(result).toContain("summon layout list --names");
+  });
+
+  test("zsh completions use 'summon layout list --names' for layout presets", () => {
+    const result = generateZshCompletion();
+    expect(result).toContain("summon layout list --names");
+  });
+});
+
+describe("fish completions setup snippet (UX-M8 #397)", () => {
+  test("fish completions include fish shell setup snippet hint", () => {
+    const result = generateFishCompletion();
+    expect(result).toContain("psub");
+  });
+});
+
 describe("custom layout completions", () => {
   test("zsh completions use dynamic command substitution for --layout (includes custom layouts at completion time)", () => {
     const result = generateZshCompletion();

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -28,10 +28,11 @@ _summon() {
     'keybindings:Generate Ghostty key table for navigation'
     'layout:Manage custom layouts'
     'session:Launch a saved multi-project session'
+    'trust:Trust the .summon file in a directory'
   )
 
   local -a config_keys=(${configKeys})
-  local -a layout_presets=(\${(f)"$(summon layout list 2>/dev/null)"})
+  local -a layout_presets=(\${(f)"$(summon layout list --names 2>/dev/null)"})
   local projects_file="\${HOME}/.config/summon/projects"
   local sessions_dir="\${HOME}/.config/summon/sessions"
   local -a session_names=()
@@ -187,10 +188,10 @@ export function generateBashCompletion(): string {
     local prev="\${COMP_WORDS[COMP_CWORD-1]}"
   fi
 
-  local subcommands="add remove list set config setup completions doctor open status switch snapshot briefing ports export freeze keybindings layout session"
+  local subcommands="add remove list set config setup completions doctor open status switch snapshot briefing ports export freeze keybindings layout session trust"
   local config_keys="${configKeys}"
   local layout_presets
-  layout_presets=$(summon layout list 2>/dev/null)
+  layout_presets=$(summon layout list --names 2>/dev/null)
   local projects_file="\${HOME}/.config/summon/projects"
   local sessions_dir="\${HOME}/.config/summon/sessions"
   local session_names=""
@@ -327,6 +328,7 @@ export function generateFishCompletion(): string {
     ["keybindings", "Generate Ghostty key table for navigation"],
     ["layout", "Manage custom layouts"],
     ["session", "Launch a saved multi-project session"],
+    ["trust", "Trust the .summon file in a directory"],
   ];
 
   const subcommandLines = subcommands
@@ -336,6 +338,7 @@ export function generateFishCompletion(): string {
   const layoutPresets = allLayouts.join(" ");
 
   return `# summon fish completion
+# Setup: eval (summon completions fish | psub)
 complete -c summon -f
 ${subcommandLines}
 complete -c summon -l help -s h -d 'Show help'

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1710,11 +1710,10 @@ describe("CLI integration", () => {
       expect(result.stderr).toContain("config");
     });
 
-    it("warns on stderr when --once is passed to 'status' subcommand", () => {
+    it("does NOT warn when --once is passed to 'status' subcommand (status legitimately uses --once) (UX-H3 #372)", () => {
       const result = run("status", "--once");
-      expect(result.stderr).toContain("Warning:");
-      expect(result.stderr).toContain("--once");
-      expect(result.stderr).toContain("status");
+      // status is in the ONCE_ALLOWED_SUBCOMMANDS allowlist — no warning should be emitted
+      expect(result.stderr).not.toContain("--once has no effect");
     });
 
     it("does not warn when --once is used with the launch flow (path argument)", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,56 +7,35 @@ import {
   showHelp,
   showSubcommandHelp,
 } from "./cli/parse.js";
-import { handleLayoutCommand } from "./commands/layout.js";
-import { handleSessionCommand } from "./commands/session.js";
-import { handleDoctorCommand } from "./commands/doctor.js";
-import {
-  handleConfigCommand,
-  handleExportCommand,
-  handleFreezeCommand,
-  handleSetCommand,
-} from "./commands/config.js";
-import {
-  handleAddCommand,
-  handleListCommand,
-  handleOpenCommand,
-  handleRemoveCommand,
-  resolveTargetDirectory,
-} from "./commands/project.js";
-import {
-  handleBriefingCommand,
-  handlePortsCommand,
-  handleSnapshotCommand,
-  handleStatusCommand,
-} from "./commands/runtime.js";
-import {
-  handleCompletionsCommand,
-  handleKeybindingsCommand,
-  handleSetupCommand,
-} from "./commands/setup.js";
+import { resolveTargetDirectory } from "./commands/project.js";
 import type { CommandHandler } from "./commands/types.js";
 
-const registry: Record<string, CommandHandler> = {
-  add: handleAddCommand,
-  remove: handleRemoveCommand,
-  list: handleListCommand,
-  set: handleSetCommand,
-  config: handleConfigCommand,
-  setup: handleSetupCommand,
-  completions: handleCompletionsCommand,
-  doctor: handleDoctorCommand,
-  keybindings: handleKeybindingsCommand,
-  freeze: handleFreezeCommand,
-  status: handleStatusCommand,
-  snapshot: handleSnapshotCommand,
-  briefing: handleBriefingCommand,
-  ports: handlePortsCommand,
-  switch: handleOpenCommand,
-  open: handleOpenCommand,
-  export: handleExportCommand,
-  layout: handleLayoutCommand,
-  session: handleSessionCommand,
+// PE-H2 (#369): Lazy-import registry — handlers are only loaded when the subcommand is used.
+const registry: Record<string, () => Promise<CommandHandler>> = {
+  add:         () => import("./commands/project.js").then(m => m.handleAddCommand),
+  remove:      () => import("./commands/project.js").then(m => m.handleRemoveCommand),
+  list:        () => import("./commands/project.js").then(m => m.handleListCommand),
+  set:         () => import("./commands/config.js").then(m => m.handleSetCommand),
+  config:      () => import("./commands/config.js").then(m => m.handleConfigCommand),
+  setup:       () => import("./commands/setup.js").then(m => m.handleSetupCommand),
+  completions: () => import("./commands/setup.js").then(m => m.handleCompletionsCommand),
+  doctor:      () => import("./commands/doctor.js").then(m => m.handleDoctorCommand),
+  keybindings: () => import("./commands/setup.js").then(m => m.handleKeybindingsCommand),
+  freeze:      () => import("./commands/config.js").then(m => m.handleFreezeCommand),
+  status:      () => import("./commands/runtime.js").then(m => m.handleStatusCommand),
+  snapshot:    () => import("./commands/runtime.js").then(m => m.handleSnapshotCommand),
+  briefing:    () => import("./commands/runtime.js").then(m => m.handleBriefingCommand),
+  ports:       () => import("./commands/runtime.js").then(m => m.handlePortsCommand),
+  switch:      () => import("./commands/project.js").then(m => m.handleOpenCommand),
+  open:        () => import("./commands/project.js").then(m => m.handleOpenCommand),
+  export:      () => import("./commands/config.js").then(m => m.handleExportCommand),
+  layout:      () => import("./commands/layout.js").then(m => m.handleLayoutCommand),
+  session:     () => import("./commands/session.js").then(m => m.handleSessionCommand),
+  trust:       () => import("./commands/trust.js").then(m => m.handleTrustCommand),
 };
+
+// UX-H3 (#372): Subcommands that legitimately consume --once — skip the false-positive warning.
+const ONCE_ALLOWED_SUBCOMMANDS = new Set(["status"]);
 
 const parsed = parseCli(process.argv.slice(2));
 
@@ -71,7 +50,7 @@ if (parsed.values.help) {
     process.exit(0);
   }
   // FE-H2 (#255): unknown subcommand with --help
-  if (parsed.subcommand && !hasSubcommandHelp(parsed.subcommand) && !registry[parsed.subcommand]) {
+  if (parsed.subcommand && !hasSubcommandHelp(parsed.subcommand) && !(parsed.subcommand in registry)) {
     console.error(`Error: Unknown command: ${parsed.subcommand}. Run 'summon --help' to see available commands.`);
     process.exit(1);
   }
@@ -79,19 +58,30 @@ if (parsed.values.help) {
   process.exit(0);
 }
 
-// UX-M8 (#314): Warn if --once is used with a non-launch subcommand
-if (parsed.values.once && parsed.subcommand && parsed.subcommand in registry) {
+// UX-M8 (#314): Warn if --once is used with a non-launch subcommand that doesn't support it.
+// UX-H3 (#372): Skip warning for subcommands that legitimately consume --once.
+if (parsed.values.once && parsed.subcommand && parsed.subcommand in registry && !ONCE_ALLOWED_SUBCOMMANDS.has(parsed.subcommand)) {
   console.error(
     `Warning: --once has no effect with the '${parsed.subcommand}' command`,
   );
 }
 
-// FE-H1 (#254): first-run wizard ONLY fires when no subcommand was supplied
-if (isFirstRun() && process.stdin.isTTY && parsed.subcommand === undefined) {
-  console.log("Press Ctrl+C at any time to skip setup. Re-run later with: summon setup");
-  const { runSetup } = await import("./setup.js");
-  await runSetup();
-  process.exit(0);
+// FE-M2 (#386): Warn if --all is passed to a non-session command.
+if (parsed.values.all && parsed.subcommand && parsed.subcommand !== "session") {
+  console.error(
+    `Warning: --all has no effect with the '${parsed.subcommand}' command. --all is only valid with 'summon session'.`,
+  );
+}
+
+// UX-H3 (#372): First-run wizard fires when no subcommand was supplied OR when targeting a directory.
+if (isFirstRun() && process.stdin.isTTY) {
+  const isDirectoryTarget = parsed.subcommand !== undefined && !(parsed.subcommand in registry);
+  if (parsed.subcommand === undefined || isDirectoryTarget) {
+    console.log("Press Ctrl+C at any time to skip setup. Re-run later with: summon setup");
+    const { runSetup } = await import("./setup.js");
+    await runSetup();
+    process.exit(0);
+  }
 }
 
 if (!parsed.subcommand) {
@@ -108,19 +98,11 @@ if (!parsed.subcommand) {
   process.exit(0);
 }
 
-// trust subcommand wiring (WU-1)
-if (parsed.subcommand === "trust") {
-  const dir = parsed.args[0] ?? ".";
-  const { trustProject } = await import("./trust.js");
-  trustProject(typeof dir === "string" ? dir : ".");
-  console.log(`✓ Trusted: ${dir}`);
-  process.exit(0);
-}
-
 const overrides = buildOverrides(parsed.values);
-const handler = registry[parsed.subcommand];
+const handlerFactory = registry[parsed.subcommand];
 
-if (handler) {
+if (handlerFactory) {
+  const handler = await handlerFactory();
   await handler({
     parsed,
     values: parsed.values,


### PR DESCRIPTION
Closes #359, #369, #370, #371, #372, #358, #386, #388, #395, #396, #397

- trust command extracted to commands/trust.ts, added to registry + help + completions
- Lazy import registry (PE-H2)
- --once allowlist for status command
- layout list --names flag for completions
- actionable unknown-flag error messages
- fish in completions help