### PR TITLE
fix(setup): re-render options on invalid input; fix preview after validation error

### DIFF
--- a/src/setup.test.ts
+++ b/src/setup.test.ts
@@ -3848,3 +3848,207 @@ describe("wizard debug logging (FE-S2)", () => {
     logSpy.mockRestore();
   });
 });
+
+// ---------------------------------------------------------------------------
+// FE-M1 (#385) — Wizard select re-renders options on invalid input
+// ---------------------------------------------------------------------------
+
+describe("numberedSelect — re-render on invalid input (FE-M1)", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    stdoutSpy.mockRestore();
+  });
+
+  it("emits cursor-up ANSI sequence on invalid input before reprinting options", async () => {
+    let callCount = 0;
+    mockQuestion.mockImplementation((_q: string, cb: (a: string) => void) => {
+      callCount++;
+      if (callCount === 1) cb("abc"); // invalid
+      else cb("1");
+    });
+    const options = [
+      { label: "A", value: "a" },
+      { label: "B", value: "b" },
+    ];
+    await numberedSelect(options, "Pick: ");
+
+    // Should emit cursor-up sequence (to move back to start of options block)
+    const stdoutCalls = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(stdoutCalls.some((c: string) => c.includes("\x1b[") && c.includes("A"))).toBe(true);
+    // Should emit clear-down sequence
+    expect(stdoutCalls.some((c: string) => c.includes("\x1b[0J"))).toBe(true);
+  });
+
+  it("reprints options after invalid input (options visible again after warning)", async () => {
+    let callCount = 0;
+    mockQuestion.mockImplementation((_q: string, cb: (a: string) => void) => {
+      callCount++;
+      if (callCount === 1) cb("99"); // out of range
+      else cb("2");
+    });
+    const options = [
+      { label: "Alpha", value: "a" },
+      { label: "Beta", value: "b" },
+    ];
+    await numberedSelect(options, "Pick: ");
+
+    const allOutput = logSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+    // Options should appear at least twice (initial print + reprint after invalid)
+    const alphaCount = allOutput.filter((s: string) => s.includes("Alpha")).length;
+    expect(alphaCount).toBeGreaterThanOrEqual(2);
+  });
+
+  it("does NOT emit cursor-up on first valid input (no re-render needed)", async () => {
+    mockQuestion.mockImplementation((_q: string, cb: (a: string) => void) => cb("1"));
+    const options = [{ label: "A", value: "a" }];
+    await numberedSelect(options, "Pick: ");
+
+    const stdoutCalls = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+    // No cursor-up should be emitted on first valid input
+    expect(stdoutCalls.some((c: string) => c.includes("\x1b[") && c.includes("A"))).toBe(false);
+  });
+});
+
+describe("selectToolFromCatalog — re-render on invalid input (FE-M1)", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    mockExecFileSync.mockReturnValue("/usr/bin/stub\n"); // all tools available
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    stdoutSpy.mockRestore();
+  });
+
+  it("emits cursor-up ANSI sequence when invalid input entered in askTool", async () => {
+    let callCount = 0;
+    mockQuestion.mockImplementation((_q: string, cb: (a: string) => void) => {
+      callCount++;
+      if (callCount === 1) cb("999"); // out of range
+      else cb("1");
+    });
+    await selectToolFromCatalog(EDITOR_CATALOG, "Editor");
+
+    const stdoutCalls = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(stdoutCalls.some((c: string) => c.includes("\x1b[") && c.includes("A"))).toBe(true);
+    expect(stdoutCalls.some((c: string) => c.includes("\x1b[0J"))).toBe(true);
+  });
+
+  it("reprints tool list after invalid input", async () => {
+    let callCount = 0;
+    mockQuestion.mockImplementation((_q: string, cb: (a: string) => void) => {
+      callCount++;
+      if (callCount === 1) cb("999"); // out of range
+      else cb("1");
+    });
+    await selectToolFromCatalog(EDITOR_CATALOG, "Editor");
+
+    const allOutput = logSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+    // Tool list lines should appear at least twice
+    const vimCount = allOutput.filter((s: string) => s.includes("vim")).length;
+    expect(vimCount).toBeGreaterThanOrEqual(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FE-M5 (#389) — PreviewRenderer.clear() + no stacked previews after validation
+// ---------------------------------------------------------------------------
+
+describe("PreviewRenderer.clear() (FE-M5)", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    stdoutSpy.mockRestore();
+  });
+
+  it("clear() emits cursor-up and clear-down when renderer is active", () => {
+    const renderer = new PreviewRenderer();
+    renderer.draw([["?"]]);
+    renderer.log("hint");
+
+    stdoutSpy.mockClear();
+    renderer.clear();
+
+    const stdoutCalls = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(stdoutCalls.some((c: string) => c.includes("A"))).toBe(true);
+    expect(stdoutCalls.some((c: string) => c.includes("\x1b[0J"))).toBe(true);
+  });
+
+  it("clear() resets internal state (subsequent draw acts as first draw)", () => {
+    const renderer = new PreviewRenderer();
+    renderer.draw([["?"]]);
+    renderer.clear();
+
+    stdoutSpy.mockClear();
+    renderer.draw([["nvim"]]);
+
+    // After clear, next draw should not emit cursor-up (acts as first draw)
+    const stdoutCalls = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(stdoutCalls.some((c: string) => c.includes("A"))).toBe(false);
+  });
+
+  it("clear() is a noop when renderer is inactive", () => {
+    const renderer = new PreviewRenderer();
+    // Don't draw anything — renderer is inactive
+    renderer.clear();
+
+    const stdoutCalls = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(stdoutCalls.some((c: string) => c.includes("A"))).toBe(false);
+    expect(stdoutCalls.some((c: string) => c.includes("\x1b[0J"))).toBe(false);
+  });
+
+  it("runLayoutBuilder: after validation stale, next preview draw is fresh (no stacking)", async () => {
+    const origIsTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, "isTTY", { value: true, writable: true });
+    mockIsValidLayoutName.mockReturnValue(true);
+    mockIsCustomLayout.mockReturnValue(false);
+
+    let callCount = 0;
+    // Command not found on first attempt, then found on second
+    mockExecFileSync.mockImplementation((_bin: string, args?: string[]) => {
+      // For template selection and confirmation prompts, return stub
+      // For command resolution: first call to "badcmd" not found, second to "nvim" found
+      if (Array.isArray(args) && args[3] === "badcmd") throw new Error("not found");
+      return "/usr/bin/stub\n";
+    });
+
+    mockQuestion.mockImplementation((_q: string, cb: (a: string) => void) => {
+      callCount++;
+      if (_q.includes("[Y/n]")) {
+        cb("y"); // confirm for "keep anyway" or save
+      } else if (_q.includes("Column 1, Pane 1")) {
+        if (callCount <= 4) cb("badcmd"); // first attempt — will be stale
+        else cb("nvim"); // valid command
+      } else {
+        cb("1");
+      }
+    });
+
+    await runLayoutBuilder("staletest");
+
+    // There should be cursor-up sequences from the clear() calls
+    const stdoutCalls = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(stdoutCalls.some((c: string) => c.includes("\x1b[") && c.includes("A"))).toBe(true);
+
+    Object.defineProperty(process.stdin, "isTTY", { value: origIsTTY, writable: true });
+  });
+});

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -119,6 +119,24 @@ export class PreviewRenderer {
     this.linesSince = 0;
     this.active = false;
   }
+
+  /**
+   * Erase the preview from the terminal and reset state.
+   * Moves cursor back to the start of the preview and clears to end of screen,
+   * so subsequent output (e.g. validation warnings) appears on a clean screen.
+   * If the renderer is inactive this is a no-op.
+   */
+  clear(): void {
+    if (this.active) {
+      const totalUp = this.lastHeight + this.linesSince;
+      process.stdout.write(ansiSyncStart());
+      process.stdout.write(ansiLineStart() + ansiUp(totalUp) + ansiClearDown());
+      process.stdout.write(ansiSyncEnd());
+    }
+    this.lastHeight = 0;
+    this.linesSince = 0;
+    this.active = false;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -464,15 +482,25 @@ export async function numberedSelect(
   promptText: string,
   defaultIdx?: number,
 ): Promise<number | typeof WIZARD_BACK> {
-  // Display options
-  for (let i = 0; i < options.length; i++) {
-    const opt = options[i]!;
-    const marker = opt.marker ?? "  ";
-    const detail = opt.detail ? `    ${dim(opt.detail)}` : "";
-    console.log(`${marker}${i + 1}) ${opt.label}${detail}`);
-  }
+  const printOptions = (): void => {
+    for (let i = 0; i < options.length; i++) {
+      const opt = options[i]!;
+      const marker = opt.marker ?? "  ";
+      const detail = opt.detail ? `    ${dim(opt.detail)}` : "";
+      console.log(`${marker}${i + 1}) ${opt.label}${detail}`);
+    }
+  };
 
-  const ask = async (): Promise<number | typeof WIZARD_BACK> => {
+  // Display options on initial render
+  printOptions();
+
+  const ask = async (isRetry = false): Promise<number | typeof WIZARD_BACK> => {
+    if (isRetry) {
+      // Move cursor back to start of options block, clear, and reprint options + warning position
+      process.stdout.write(ansiLineStart() + ansiUp(options.length) + ansiClearDown());
+      printOptions();
+    }
+
     const trimmed = await promptUser(promptText);
 
     if (trimmed === "b" || trimmed === "back") {
@@ -490,7 +518,7 @@ export async function numberedSelect(
           `  Invalid selection. Please enter a number between 1 and ${options.length}.`,
         ),
       );
-      return ask();
+      return ask(true);
     }
 
     return num - 1;
@@ -721,14 +749,27 @@ export async function selectToolFromCatalog(
     return askCustom();
   }
 
-  // Display only available tools
-  for (let i = 0; i < available.length; i++) {
-    const t = available[i]!;
-    console.log(`  * ${i + 1}) ${t.cmd.padEnd(10)} ${t.name}    ${dim(t.desc)}`);
-  }
-  console.log(`    c) Custom command`);
+  // The tool list height is available.length tool rows + 1 "c) Custom" row
+  const toolListHeight = available.length + 1;
 
-  const askTool = async (): Promise<string> => {
+  const printToolList = (): void => {
+    for (let i = 0; i < available.length; i++) {
+      const t = available[i]!;
+      console.log(`  * ${i + 1}) ${t.cmd.padEnd(10)} ${t.name}    ${dim(t.desc)}`);
+    }
+    console.log(`    c) Custom command`);
+  };
+
+  // Display only available tools
+  printToolList();
+
+  const askTool = async (isRetry = false): Promise<string> => {
+    if (isRetry) {
+      // Move cursor back to start of tool list, clear, and reprint
+      process.stdout.write(ansiLineStart() + ansiUp(toolListHeight) + ansiClearDown());
+      printToolList();
+    }
+
     const trimmed = (await promptUser(`  Select (default: 1): `)).toLowerCase();
     if (trimmed === "") {
       return available[0]!.cmd;
@@ -743,7 +784,7 @@ export async function selectToolFromCatalog(
           `  Invalid selection. Please enter a number between 1 and ${available.length}, or "c" for custom.`,
         ),
       );
-      return askTool();
+      return askTool(true);
     }
     return available[num - 1]!.cmd;
   };
@@ -1400,11 +1441,11 @@ export async function runLayoutBuilder(name: string): Promise<void> {
           `  Column ${c + 1}, Pane ${p + 1} \u2014 command [shell]: `,
         );
         cmd = input || "shell";
-        const { cmd: validated, rendererStale } = await validateBuilderCommand(cmd, availableCmds);
-        if (rendererStale) {
-          // Validation printed extra lines — line counts are unreliable now
-          renderer.reset();
-        }
+        // Clear the preview before validation (while cursor math is still accurate),
+        // so any warning output from validateBuilderCommand appears on a clean screen.
+        // FE-M5 (#389): prevents stacked duplicate previews after validation errors.
+        renderer.clear();
+        const { cmd: validated } = await validateBuilderCommand(cmd, availableCmds);
         cmd = validated;
       }
       column.push(cmd);


### PR DESCRIPTION
Closes #385, #389

- numberedSelect re-renders full option list on invalid input
- PreviewRenderer.clear() prevents stacking duplicate previews