### PR TITLE
fix(ci): expand smoke test, E2E in CI, Node 24, rollback docs, SECURITY.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # Vite 8 supports Node 20.19+ and 22.12+.
-        node-version: [20, 22]
+        # Vite 8 supports Node 20.19+ and 22.12+. Node 24 added for forward-compat.
+        node-version: [20, 22, 24]
         os: [macos-latest]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -29,3 +29,17 @@ jobs:
       - run: pnpm lint
       - run: pnpm test
       - run: pnpm build
+
+  e2e:
+    # AppleScript syntax E2E — runs osacompile (available on any macOS, no Ghostty needed)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: 22
+      - run: corepack enable
+      - run: corepack prepare pnpm@10.29.2 --activate
+      - run: pnpm install --frozen-lockfile
+      - name: Run AppleScript E2E suite
+        run: SUMMON_E2E=1 pnpm test:e2e

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,9 +52,23 @@ jobs:
           tar tzf "$TARBALL" | grep -E "(index\.js|bin)" || (echo "ERROR: Missing expected files in tarball" && exit 1)
           npm install -g "$TARBALL"
           summon --version
+          summon --help
+          summon doctor
 
-      # IMPORTANT: Configure trusted publisher on npmjs.com for OIDC to work
-      # Until OIDC is configured on npmjs.com, NODE_AUTH_TOKEN is used as fallback
+      - name: AppleScript E2E smoke test
+        # Validates generated AppleScript syntax via osacompile (no Ghostty needed)
+        run: SUMMON_E2E=1 pnpm test:e2e
+
+      # TODO: OIDC — migrate away from long-lived NPM_TOKEN
+      # Current state: NODE_AUTH_TOKEN (NPM_TOKEN secret) is the active publish credential.
+      # id-token: write is declared above but OIDC trusted publishing is NOT yet active.
+      #
+      # To complete the migration:
+      #   1. Go to https://www.npmjs.com/package/summon-ws -> Settings -> Publishing
+      #   2. Add a trusted publisher: GitHub Actions, repo juan294/summon, workflow release.yml
+      #   3. Once configured, remove NODE_AUTH_TOKEN from the Publish step below.
+      #      The --provenance flag will then use the OIDC token automatically.
+      #   4. Revoke the NPM_TOKEN secret from GitHub Settings -> Secrets.
       - name: Publish
         run: npm publish summon-ws-*.tgz --provenance --access public
         env:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,17 +1,67 @@
 # Security Policy
 
-## Reporting a Vulnerability
-
-Please **do not** open a public GitHub issue for security vulnerabilities.
-
-Report security issues privately via [GitHub Security Advisories](https://github.com/juan294/summon/security/advisories/new).
-
-We will respond within 48 hours and coordinate a fix before any public disclosure.
-
 ## Supported Versions
 
-Only the latest published version on npm receives security fixes.
+Only the current major release receives security patches.
+
+| Version | Supported |
+|---------|-----------|
+| 1.x     | Yes       |
+| < 1.0   | No        |
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+### Preferred: GitHub Private Vulnerability Reporting
+
+Use GitHub's built-in private disclosure mechanism:
+
+1. Go to https://github.com/juan294/summon/security/advisories
+2. Click "Report a vulnerability"
+3. Fill in the details — include steps to reproduce, impact assessment, and any suggested mitigations
+
+### Alternative: Email
+
+Send a report to **juan294@gmail.com** with the subject line:
+`[summon] Security vulnerability report`
+
+Include:
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fix (if any)
+
+## Disclosure Timeline
+
+| Milestone | Target |
+|-----------|--------|
+| Acknowledge receipt | Within 48 hours |
+| Initial assessment | Within 5 days |
+| Patch for critical issues | Within 14 days of confirmation |
+| Patch for non-critical issues | Within 60 days |
+| Public disclosure | After patch is released |
+
+We follow coordinated disclosure. We will notify you before publishing any advisory.
+
+## Injection Defense Gate
+
+`src/shell-escape.lint.test.ts` is the primary injection defense for this project. It is a **load-bearing CI gate** that statically scans all source files and fails if any raw template literal interpolates a user-controlled value into an AppleScript or shell context.
+
+**This test must never be removed or disabled.** Its removal would silently eliminate the primary defense against AppleScript/shell injection in the generated workspace scripts. See `src/shell-escape.ts` for the escape functions it protects.
+
+If you discover that this test can be bypassed — for example, through a code path that constructs AppleScript outside of the tracked escape functions — please report it as a security vulnerability using the process above.
 
 ## Security Model
 
 Summon executes commands configured in `.summon` project files. As of v0.8.0+, project `.summon` files require explicit trust (`summon trust .`) before their commands are executed. See the README for details on the trust model.
+
+## Scope
+
+This tool runs on macOS only and invokes `osascript` with generated AppleScript. The main attack surface is:
+
+- **AppleScript injection** via workspace config values (project names, commands, environment variables)
+- **Shell injection** via the same config values when constructing shell commands
+- **Trust bypass** in the `.summon` file allowlist (`src/trust.ts`)
+
+Out of scope: issues requiring physical access to the machine, issues in development dependencies not affecting the published CLI.

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -100,6 +100,56 @@ summon .
 - [ ] Push the tag: `git push origin v<version>`
 - [ ] Create a GitHub release from the tag
 
+## Rollback
+
+If a bad version is published, act quickly — npm does not allow unpublishing versions older than 72 hours.
+
+### 1. Deprecate the bad version
+
+This keeps the package installable but warns users away:
+
+```bash
+npm deprecate summon-ws@<bad-version> "Critical bug — use <previous-version> instead"
+```
+
+### 2. Repoint the `latest` dist-tag to the last good version
+
+```bash
+npm dist-tag add summon-ws@<good-version> latest
+```
+
+After this, `npm install -g summon-ws` will install the good version again.
+
+### 3. Publish a canary fix before promoting to `latest`
+
+If you have a fix ready but want to test it before making it the default:
+
+```bash
+# Publish under the `next` tag — does NOT affect `latest`
+npm publish --tag next
+
+# Verify it works:
+npm install -g summon-ws@next
+summon --version
+summon --help
+summon doctor
+
+# Promote to latest once verified:
+npm dist-tag add summon-ws@<fixed-version> latest
+```
+
+### 4. Post-incident verification
+
+Confirm dist-tags are pointing at the right versions:
+
+```bash
+npm info summon-ws dist-tags
+# Should show: { latest: '<good-version>', ... }
+
+npm info summon-ws@latest version
+# Must match the intended good version
+```
+
 ## Supply Chain
 
 Consider adding SBOM generation (`cyclonedx-node`) to the release workflow for future releases.


### PR DESCRIPTION
Closes #366, #367, #381, #382, #383, #384, #391

- Release smoke test runs --version + --help + doctor
- SUMMON_E2E=1 in CI and release workflows
- Node 24 added to CI matrix
- Rollback playbook in publishing.md
- SECURITY.md created