### PR TITLE
release: v1.5.2 — session --all skip untrusted projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.2] - 2026-05-19
+
+### Fixed
+
+- **`summon session --all` no longer aborts on the first untrusted project.**
+  Encountering an untrusted `.summon` file used to terminate the whole session
+  via `process.exit(1)` from inside `launch()`, with the spinner swallowing the
+  error so the user saw only a few tabs open and no clear reason. The trust
+  gate now rethrows `SummonError`, and `session` catches it per-project: prints
+  a warning with the exact `summon trust <path>` hint, continues with the
+  remaining projects, and reports `N launched, M skipped (untrusted)` at the
+  end. Direct `summon <project>` launches still exit cleanly on untrusted
+  files via a top-level catch in the CLI entry.
+
 ## [1.5.1] - 2026-05-19
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "summon-ws",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Launch configurable multi-pane Ghostty workspaces with one command",
   "type": "module",
   "packageManager": "pnpm@10.29.2",

--- a/src/commands/session.test.ts
+++ b/src/commands/session.test.ts
@@ -241,6 +241,47 @@ describe("session launch --all", () => {
   });
 });
 
+describe("session launch — skip untrusted projects and continue", () => {
+  it("skips a project that fails the trust gate and continues with the rest", async () => {
+    const { SummonError } = await import("../trust.js");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    mockListProjects.mockReturnValue(
+      new Map([
+        ["api", "/tmp/api"],
+        ["web", "/tmp/web"],
+        ["worker", "/tmp/worker"],
+      ]),
+    );
+    mockGetProject.mockImplementation((name: string) => {
+      const map: Record<string, string> = { api: "/tmp/api", web: "/tmp/web", worker: "/tmp/worker" };
+      return map[name];
+    });
+    // Second project is untrusted; first and third succeed.
+    mockLaunch
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new SummonError("This project has a .summon file. Run 'summon trust .' to allow it."))
+      .mockResolvedValueOnce(undefined);
+
+    await handleSessionCommand(makeContext({ values: { all: true }, args: [] }));
+
+    // All three were attempted; the untrusted one was skipped, not fatal.
+    expect(mockLaunch).toHaveBeenCalledTimes(3);
+    const allWarns = warnSpy.mock.calls.map((c) => c[0] as string).join("\n");
+    expect(allWarns).toContain("web");
+    expect(allWarns.toLowerCase()).toContain("untrusted");
+    const allLogs = logSpy.mock.calls.map((c) => c[0] as string).join("\n");
+    expect(allLogs).toContain("Session complete");
+
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+});
+
 describe("session launch --new-window <name>", () => {
   it("first call has new-window: 'true' and no new-tab; second call has new-tab: 'true' and no new-window key", async () => {
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});

--- a/src/commands/session.ts
+++ b/src/commands/session.ts
@@ -7,6 +7,7 @@ import {
   deleteSession,
   isValidSessionName,
 } from "../sessions.js";
+import { SummonError } from "../trust.js";
 import { exitWithUsageHint, getErrorMessage } from "../utils.js";
 import type { CommandContext } from "./types.js";
 
@@ -100,20 +101,36 @@ async function cmdLaunch(ctx: CommandContext, name: string | undefined): Promise
 
   const total = projects.length;
   const launched: string[] = [];
+  const skippedUntrusted: string[] = [];
+  // Treat first-launch placement the same regardless of whether earlier
+  // projects were skipped: the first *successful* launch opens the window,
+  // every subsequent one opens a new tab.
+  let openedFirst = false;
   const baseOverrides = { ...ctx.overrides };
 
   for (let i = 0; i < total; i++) {
     const proj = projects[i]!;
     const dir = getProject(proj)!;
-    const overrides = { ...baseOverrides, "new-tab": i > 0 ? "true" : undefined };
-    if (i > 0) {
+    const overrides = { ...baseOverrides, "new-tab": openedFirst ? "true" : undefined };
+    if (openedFirst) {
       delete overrides["new-window"];
     }
     try {
       await runWithSpinner(`[${i + 1}/${total}] Summoning ${proj}...`, () => launch(dir, overrides));
       console.log(`[${i + 1}/${total}] Launched ${proj}`);
       launched.push(proj);
+      openedFirst = true;
     } catch (err) {
+      // Trust failures are recoverable for a multi-project session: warn,
+      // tell the user how to fix it, and continue with the remaining projects.
+      // Any other failure (osascript error, missing directory, etc.) aborts
+      // the whole session — those are not safely retryable per-project.
+      if (err instanceof SummonError) {
+        console.warn(`[${i + 1}/${total}] Skipped ${proj} — untrusted .summon file.`);
+        console.warn(`  Run 'summon trust ${dir}' to allow it, then re-run.`);
+        skippedUntrusted.push(proj);
+        continue;
+      }
       console.error(`Error launching ${proj}: ${getErrorMessage(err)}`);
       if (launched.length > 0) {
         console.error(`Already launched: ${launched.join(", ")}`);
@@ -122,7 +139,13 @@ async function cmdLaunch(ctx: CommandContext, name: string | undefined): Promise
     }
   }
 
-  console.log(`✓ Session complete: ${total} project(s) launched.`);
+  if (skippedUntrusted.length > 0) {
+    console.log(
+      `✓ Session complete: ${launched.length} launched, ${skippedUntrusted.length} skipped (untrusted): ${skippedUntrusted.join(", ")}`,
+    );
+  } else {
+    console.log(`✓ Session complete: ${total} project(s) launched.`);
+  }
 }
 
 async function cmdAdd(rest: string[], _ctx: CommandContext): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { isFirstRun } from "./config.js";
 import { launch } from "./launcher.js";
+import { SummonError } from "./trust.js";
 import {
   buildOverrides,
   hasSubcommandHelp,
@@ -116,5 +117,13 @@ if (handlerFactory) {
   // Not a known subcommand — treat as a workspace target (path or registered project name).
   // resolveTargetDirectory handles path resolution, project registry lookup, and error reporting.
   const targetDir = resolveTargetDirectory(parsed.subcommand);
-  await launch(targetDir, overrides);
+  try {
+    await launch(targetDir, overrides);
+  } catch (err) {
+    if (err instanceof SummonError) {
+      console.error(err.message);
+      process.exit(1);
+    }
+    throw err;
+  }
 }

--- a/src/launcher.test.ts
+++ b/src/launcher.test.ts
@@ -3628,7 +3628,7 @@ describe("newWindow and newTab mutual exclusion", () => {
 });
 
 describe("QA-M3: security gate branches (trust + dangerous command skip)", () => {
-  it("exits with error message when assertTrustedContent throws SummonError", async () => {
+  it("rethrows SummonError when assertTrustedContent rejects an untrusted file", async () => {
     const { SummonError } = await import("./trust.js");
     mockAssertTrustedContent.mockImplementation(() => {
       throw new SummonError("Untrusted .summon file. Run 'summon trust .' to allow it.");
@@ -3638,19 +3638,8 @@ describe("QA-M3: security gate branches (trust + dangerous command skip)", () =>
       throw new SummonError("Untrusted .summon file. Run 'summon trust .' to allow it.");
     });
 
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
-      throw new Error("process.exit called");
-    });
-
-    await expect(launch("/tmp/workspace")).rejects.toThrow("process.exit called");
-    expect(exitSpy).toHaveBeenCalledWith(1);
-    expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Untrusted .summon file"),
-    );
-
-    errorSpy.mockRestore();
-    exitSpy.mockRestore();
+    await expect(launch("/tmp/workspace")).rejects.toBeInstanceOf(SummonError);
+    await expect(launch("/tmp/workspace")).rejects.toThrow(/Untrusted \.summon file/);
   });
 
   it("non-SummonError from assertTrustedContent is rethrown (not swallowed)", async () => {

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -21,7 +21,7 @@ import { parseTreeDSL, extractPaneDefinitions, extractPaneCwds, resolveTreeComma
 import type { LayoutNode } from "./tree.js";
 import { resolveCommand as resolveCommandPath, getErrorMessage, SUMMON_WORKSPACE_ENV, promptUser, ACCESSIBILITY_SETTINGS_PATH } from "./utils.js";
 import { ensureGhostty, ensureAccessibility, printAccessibilityHint, confirmDangerousCommands, isAccessibilityError } from "./launch-guards.js";
-import { assertTrusted, assertTrustedContent, SummonError } from "./trust.js";
+import { assertTrusted, assertTrustedContent } from "./trust.js";
 import { parseIntInRange, parsePositiveFloat, ENV_KEY_RE, PROJECT_NAME_RE, sanitizeProjectName } from "./validation.js";
 import { isStarshipInstalled, ensurePresetConfig, getPresetConfigPath } from "./starship.js";
 // command-spec is a pure utility module with no imports from this file.
@@ -783,20 +783,16 @@ export async function launch(targetDir: string, cliOverrides?: CLIOverrides): Pr
 
   // Trust gate: verify the .summon file (if present) is explicitly trusted before
   // reading or acting on any of its values (BE-B1, BE-B2, SE-H1).
-  try {
-    if (cliOverrides?.["no-project-config"] === "true") {
-      // skip trust check
-    } else if (summonFileContent !== undefined) {
-      assertTrustedContent(targetDir, summonFileContent);
-    } else {
-      assertTrusted(targetDir);
-    }
-  } catch (err) {
-    if (err instanceof SummonError) {
-      console.error(err.message);
-      process.exit(1);
-    }
-    throw err;
+  // SummonError is rethrown so callers (e.g. `session --all`) can choose to skip
+  // an untrusted project and continue with the rest, instead of terminating the
+  // whole process. The top-level direct-launch entry catches SummonError and
+  // converts it to a clean exit 1 with the user-facing message.
+  if (cliOverrides?.["no-project-config"] === "true") {
+    // skip trust check
+  } else if (summonFileContent !== undefined) {
+    assertTrustedContent(targetDir, summonFileContent);
+  } else {
+    assertTrusted(targetDir);
   }
 
   let config: ReturnType<typeof resolveConfig>;


### PR DESCRIPTION
## Summary
- `summon session --all` no longer aborts on the first untrusted project — the trust gate rethrows `SummonError` and `session` catches it per-project, warning with the exact `summon trust <path>` hint and continuing with the rest.
- Direct `summon <project>` still exits cleanly on untrusted `.summon` files via a top-level catch in the CLI entry.
- Adds regression tests: launcher rethrow assertion + session skip-and-continue on `--all`.

## CHANGELOG
See `[1.5.2] - 2026-05-19` in CHANGELOG.md.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 1916 passed, 1 skipped
- [x] `pnpm build` clean
- [ ] CI green on main after merge
- [ ] Manual smoke: `summon session --all` with at least one untrusted project skips it and finishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)