### PR TITLE
ci: run build matrix on ubuntu, keep only AppleScript E2E on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,49 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    runs-on: ${{ matrix.os }}
+  # Node-version-invariant checks run ONCE on the cheap Linux runner.
+  # typecheck (tsc), lint (eslint) and build (tsup) produce identical results
+  # across Node 20/22/24, so fanning them across the version matrix only paid
+  # for redundant work. They are also platform-agnostic (no osascript/Ghostty),
+  # so they run on ubuntu-latest — billed 1× versus 10× for macOS runners.
+  checks:
+    name: Typecheck · Lint · Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+      - run: corepack enable
+      - run: corepack prepare pnpm@10.29.2 --activate
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "dir=$(pnpm store path)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v5
+        with:
+          path: ${{ steps.pnpm-cache.outputs.dir }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm typecheck
+      - run: pnpm lint
+      - run: pnpm build
+
+  # Unit tests DO vary by Node version, so this is the only leg that fans out.
+  # All unit tests mock node:child_process (osascript/execSync/execFileSync are
+  # never invoked for real), and the macOS-only AppleScript E2E is gated behind
+  # SUMMON_E2E (unset here) — so the suite is platform-agnostic and runs on the
+  # 1×-billed Linux runner instead of the 10×-billed macOS one.
+  test:
+    name: Test (Node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
       matrix:
         # Vite 8 supports Node 20.19+ and 22.12+. Node 24 added for forward-compat.
         node-version: [20, 22, 24]
-        os: [macos-latest]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -39,11 +74,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-
       - run: pnpm install --frozen-lockfile
-      - run: pnpm typecheck
-      - run: pnpm lint
       - run: pnpm test
-      - run: pnpm build
 
+  # The ONLY job that genuinely needs macOS: osacompile must resolve Ghostty's
+  # scripting dictionary, which only exists on macOS. Kept on macos-latest.
   e2e-applescript:
     name: AppleScript syntax E2E (macOS)
     runs-on: macos-latest


### PR DESCRIPTION
## What

Move the version-matrix CI work off the 10×-billed `macos-latest` runner. Only the AppleScript E2E job genuinely needs macOS (osacompile must resolve Ghostty's scripting dictionary); everything else is platform-agnostic.

## Why (cost, not speed)

All jobs ran on `macos-latest`, billed at **10×** the Linux rate. The 3× `build` matrix (Node 20/22/24) ran tsc/eslint/vitest/tsup — none of which need macOS:

- Unit tests mock `node:child_process`, so `osascript`/`execSync`/`execFileSync` are never invoked for real.
- The macOS-only AppleScript E2E is gated behind `SUMMON_E2E` (unset in the build matrix), so `pnpm test` already skips it there. Verified locally: `1 skipped`.

## Changes

- **FIX 1 (cost):** `build` matrix → `ubuntu-latest`; only `e2e-applescript` stays on `macos-latest`.
- **FIX 2 (redundancy):** Split the Node-version-invariant checks (typecheck/lint/build) into a single `checks` job that runs **once**, and fan only `pnpm test` across Node 20/22/24.

## Impact

| | Before | After |
|---|---|---|
| macOS jobs (10× billed) | 4 (3× build matrix + 1 e2e) | 1 (e2e only) |
| typecheck+lint runs | 3× | 1× |
| billed macOS minutes | baseline | **~75% reduction** |

Wall-clock is roughly unchanged (~70s); the win is billed runner-minutes.

## Validation

- `actionlint` clean (only pre-existing info-level SC2086 notes on unchanged `$GITHUB_OUTPUT` lines).
- `python3 -c "yaml.safe_load(...)"` OK.
- Local `pnpm typecheck && lint && build && test` all green (2412 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)